### PR TITLE
Fix Regal download URL in GitHub workflow

### DIFF
--- a/.github/workflows/opa-ci.yaml
+++ b/.github/workflows/opa-ci.yaml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Install Regal
         run: |
-          curl -L -o regal.tar.gz https://github.com/StyraInc/regal/releases/latest/download/regal_Linux_x86_64.tar.gz
-          tar -xzf regal.tar.gz
+          curl -L -o regal https://github.com/StyraInc/regal/releases/latest/download/regal_Linux_x86_64
+          chmod +x regal
           sudo mv regal /usr/local/bin/
           regal --version
 


### PR DESCRIPTION
This PR fixes the Regal download URL in the GitHub workflow. The current URL is incorrect and causes the workflow to fail.