### PR TITLE
Fix Regal version command in GitHub workflow

### DIFF
--- a/.github/workflows/opa-ci.yaml
+++ b/.github/workflows/opa-ci.yaml
@@ -29,7 +29,7 @@ jobs:
           curl -L -o regal https://github.com/StyraInc/regal/releases/latest/download/regal_Linux_x86_64
           chmod +x regal
           sudo mv regal /usr/local/bin/
-          regal --version
+          regal version
 
       - name: Run OPA Check
         run: opa check .


### PR DESCRIPTION
This PR fixes the Regal version command in the GitHub workflow. The current command uses '--version' flag which is no longer supported. The correct command is 'regal version'.