### PR TITLE
Update .github/README.md with correct Regal installation instructions

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -31,8 +31,8 @@ chmod 755 opa
 sudo mv opa /usr/local/bin/
 
 # Install Regal
-curl -L -o regal.tar.gz https://github.com/StyraInc/regal/releases/latest/download/regal_Linux_x86_64.tar.gz
-tar -xzf regal.tar.gz
+curl -L -o regal https://github.com/StyraInc/regal/releases/latest/download/regal_Linux_x86_64
+chmod +x regal
 sudo mv regal /usr/local/bin/
 
 # Install the pre-commit hooks


### PR DESCRIPTION
This PR updates the .github/README.md file with the correct Regal installation instructions. The previous instructions were using the tar.gz approach, but Regal now provides the binary directly.