### PR TITLE
fix(hero-banner): center {} braces in the hexagon

### DIFF
--- a/diagrams/hero_banner_dark.svg
+++ b/diagrams/hero_banner_dark.svg
@@ -3,7 +3,7 @@
 <title>GOPAL</title>
 <desc>GOPAL hero banner with logo, wordmark, tagline, and framework badges.</desc>
 <polygon points="40,88 56,60 88,60 104,88 88,116 56,116" fill="#6366f1"/>
-<g fill="none" stroke="#ffffff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" transform="translate(32, 62) scale(0.65)">
+<g fill="none" stroke="#ffffff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" transform="translate(46, 62) scale(0.65)">
 <path d="M 34 24 Q 26 24 26 32 Q 26 40 22 40 Q 26 40 26 48 Q 26 56 34 56"/>
 <path d="M 46 24 Q 54 24 54 32 Q 54 40 58 40 Q 54 40 54 48 Q 54 56 46 56"/>
 </g>

--- a/diagrams/hero_banner_light.svg
+++ b/diagrams/hero_banner_light.svg
@@ -3,7 +3,7 @@
 <title>GOPAL</title>
 <desc>GOPAL hero banner with logo, wordmark, tagline, and framework badges.</desc>
 <polygon points="40,88 56,60 88,60 104,88 88,116 56,116" fill="#4f46e5"/>
-<g fill="none" stroke="#ffffff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" transform="translate(32, 62) scale(0.65)">
+<g fill="none" stroke="#ffffff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" transform="translate(46, 62) scale(0.65)">
 <path d="M 34 24 Q 26 24 26 32 Q 26 40 22 40 Q 26 40 26 48 Q 26 56 34 56"/>
 <path d="M 46 24 Q 54 24 54 32 Q 54 40 58 40 Q 54 40 54 48 Q 54 56 46 56"/>
 </g>


### PR DESCRIPTION
## Summary

One-line transform fix. The \`{}\` glyph in \`diagrams/hero_banner_{light,dark}.svg\` was sitting 14 units left of the hex centre because the transform was \`translate(32, 62)\` when the math actually requires \`translate(46, 62)\`.

In the 80×80 brace frame the glyph is already centred at (40, 40). After \`scale(0.65)\` its centre lands at (26, 26). The translate must therefore put (26, 26) at the hex centre (72, 88), i.e. \`translate(46, 62)\`.

Logo and OG card were unaffected — those use the hexagon at its origin position where its centre already sits at (40, 40) in the local frame, with no extra transform applied.

## Test plan

- [x] Visually verified in Inkscape at 2× rendering