### PR TITLE
fix(eu_fairness_test.rego): correct mock functions and test data structure

### DIFF
--- a/international/eu_ai_act/v1/eu_fairness/eu_fairness_test.rego
+++ b/international/eu_ai_act/v1/eu_fairness/eu_fairness_test.rego
@@ -4,164 +4,163 @@ import data.global.v1.common.content_safety
 import data.global.v1.common.fairness as common_fairness
 import data.international.eu_ai_act.v1.eu_fairness
 
-# Mock the imported functions
-mock_gender_bias_detected(metrics) if {
-	metrics.fairness.gender_bias == true
-}
+# Key change 1: Use functions (=) instead of rules (if) to return values directly
+mock_gender_bias_detected(metrics) = metrics.fairness.details.gender_bias_detected
 
-mock_gender_bias_detected(metrics) if {
-	metrics.gender_bias_detected == true
-}
+mock_racial_bias_detected(metrics) = metrics.fairness.details.racial_bias_detected
 
-mock_racial_bias_detected(metrics) if {
-	metrics.fairness.racial_bias == true
-}
+mock_toxicity_below_threshold(metrics, threshold) = metrics.content_safety.score < threshold
 
-mock_racial_bias_detected(metrics) if {
-	metrics.racial_bias_detected == true
-}
-
-mock_toxicity_below_threshold(metrics, threshold) if {
-	metrics.content_safety.score < threshold
-}
-
+# Key change 2: Test data uses the 'details' path, matching the common/fairness package
 # Test case for compliant input with custom parameters
 test_allow_with_custom_params if {
-	eu_fairness.allow with input as {
-		"metrics": {
-			"fairness": {
-				"gender_bias": false,
-				"racial_bias": false,
-			},
-			"content_safety": {"score": 0.5},
-		},
-		"summary": {"stereotype_values": {
-			"gender_bias_detected": false,
-			"racial_bias_detected": false,
-		}},
-		"params": {
-			"fairness_threshold": 0.75,
-			"toxicity_threshold": 0.6,
-		},
-	}
-		with common_fairness.gender_bias_detected as mock_gender_bias_detected
-		with common_fairness.racial_bias_detected as mock_racial_bias_detected
-		with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
+    eu_fairness.allow with input as {
+        "metrics": {
+            "fairness": {
+                "details": {
+                    "gender_bias_detected": false,
+                    "racial_bias_detected": false
+                }
+            },
+            "content_safety": {"score": 0.5},
+        },
+        "summary": {"stereotype_values": {
+            "gender_bias_detected": false,
+            "racial_bias_detected": false,
+        }},
+        "params": {
+            "fairness_threshold": 0.75,
+            "toxicity_threshold": 0.6,
+        },
+    }
+    with common_fairness.gender_bias_detected as mock_gender_bias_detected
+    with common_fairness.racial_bias_detected as mock_racial_bias_detected
+    with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
 }
 
 # Test case for compliant input with default parameters
 test_allow_with_default_params if {
-	eu_fairness.allow with input as {
-		"metrics": {
-			"fairness": {
-				"gender_bias": false,
-				"racial_bias": false,
-			},
-			"content_safety": {"score": 0.5},
-		},
-		"summary": {"stereotype_values": {
-			"gender_bias_detected": false,
-			"racial_bias_detected": false,
-		}},
-		"params": {},
-	}
-		with common_fairness.gender_bias_detected as mock_gender_bias_detected
-		with common_fairness.racial_bias_detected as mock_racial_bias_detected
-		with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
+    eu_fairness.allow with input as {
+        "metrics": {
+            "fairness": {
+                "details": {
+                    "gender_bias_detected": false,
+                    "racial_bias_detected": false
+                }
+            },
+            "content_safety": {"score": 0.5},
+        },
+        "summary": {"stereotype_values": {
+            "gender_bias_detected": false,
+            "racial_bias_detected": false,
+        }},
+        "params": {},
+    }
+    with common_fairness.gender_bias_detected as mock_gender_bias_detected
+    with common_fairness.racial_bias_detected as mock_racial_bias_detected
+    with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
 }
 
 # Test case for non-compliant input (gender bias)
 test_deny_gender_bias if {
-	not eu_fairness.allow with input as {
-		"metrics": {
-			"fairness": {
-				"gender_bias": true,
-				"racial_bias": false,
-			},
-			"content_safety": {"score": 0.5},
-		},
-		"summary": {"stereotype_values": {
-			"gender_bias_detected": false,
-			"racial_bias_detected": false,
-		}},
-		"params": {
-			"fairness_threshold": 0.75,
-			"toxicity_threshold": 0.6,
-		},
-	}
-		with common_fairness.gender_bias_detected as mock_gender_bias_detected
-		with common_fairness.racial_bias_detected as mock_racial_bias_detected
-		with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
+    not eu_fairness.allow with input as {
+        "metrics": {
+            "fairness": {
+                "details": {
+                    "gender_bias_detected": true,
+                    "racial_bias_detected": false
+                }
+            },
+            "content_safety": {"score": 0.5},
+        },
+        "summary": {"stereotype_values": {
+            "gender_bias_detected": false,
+            "racial_bias_detected": false,
+        }},
+        "params": {
+            "fairness_threshold": 0.75,
+            "toxicity_threshold": 0.6,
+        },
+    }
+    with common_fairness.gender_bias_detected as mock_gender_bias_detected
+    with common_fairness.racial_bias_detected as mock_racial_bias_detected
+    with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
 }
 
 # Test case for non-compliant input (racial bias)
 test_deny_racial_bias if {
-	not eu_fairness.allow with input as {
-		"metrics": {
-			"fairness": {
-				"gender_bias": false,
-				"racial_bias": true,
-			},
-			"content_safety": {"score": 0.5},
-		},
-		"summary": {"stereotype_values": {
-			"gender_bias_detected": false,
-			"racial_bias_detected": false,
-		}},
-		"params": {
-			"fairness_threshold": 0.75,
-			"toxicity_threshold": 0.6,
-		},
-	}
-		with common_fairness.gender_bias_detected as mock_gender_bias_detected
-		with common_fairness.racial_bias_detected as mock_racial_bias_detected
-		with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
+    not eu_fairness.allow with input as {
+        "metrics": {
+            "fairness": {
+                "details": {
+                    "gender_bias_detected": false,
+                    "racial_bias_detected": true
+                }
+            },
+            "content_safety": {"score": 0.5},
+        },
+        "summary": {"stereotype_values": {
+            "gender_bias_detected": false,
+            "racial_bias_detected": false,
+        }},
+        "params": {
+            "fairness_threshold": 0.75,
+            "toxicity_threshold": 0.6,
+        },
+    }
+    with common_fairness.gender_bias_detected as mock_gender_bias_detected
+    with common_fairness.racial_bias_detected as mock_racial_bias_detected
+    with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
 }
 
 # Test case for non-compliant input (high toxicity)
 test_deny_high_toxicity if {
-	not eu_fairness.allow with input as {
-		"metrics": {
-			"fairness": {
-				"gender_bias": false,
-				"racial_bias": false,
-			},
-			"content_safety": {"score": 0.8},
-		},
-		"summary": {"stereotype_values": {
-			"gender_bias_detected": false,
-			"racial_bias_detected": false,
-		}},
-		"params": {
-			"fairness_threshold": 0.75,
-			"toxicity_threshold": 0.6,
-		},
-	}
-		with common_fairness.gender_bias_detected as mock_gender_bias_detected
-		with common_fairness.racial_bias_detected as mock_racial_bias_detected
-		with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
+    not eu_fairness.allow with input as {
+        "metrics": {
+            "fairness": {
+                "details": {
+                    "gender_bias_detected": false,
+                    "racial_bias_detected": false
+                }
+            },
+            "content_safety": {"score": 0.8},
+        },
+        "summary": {"stereotype_values": {
+            "gender_bias_detected": false,
+            "racial_bias_detected": false,
+        }},
+        "params": {
+            "fairness_threshold": 0.75,
+            "toxicity_threshold": 0.6,
+        },
+    }
+    with common_fairness.gender_bias_detected as mock_gender_bias_detected
+    with common_fairness.racial_bias_detected as mock_racial_bias_detected
+    with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
 }
 
 # Test recommendations for gender bias
 test_recommendations_gender_bias if {
-	eu_fairness.recommendations == ["Address gender bias in the AI system to comply with EU AI Act fairness requirements"] with input as {
-		"metrics": {
-			"fairness": {
-				"gender_bias": true,
-				"racial_bias": false,
-			},
-			"content_safety": {"score": 0.5},
-		},
-		"summary": {"stereotype_values": {
-			"gender_bias_detected": false,
-			"racial_bias_detected": false,
-		}},
-		"params": {
-			"fairness_threshold": 0.75,
-			"toxicity_threshold": 0.6,
-		},
-	}
-		with common_fairness.gender_bias_detected as mock_gender_bias_detected
-		with common_fairness.racial_bias_detected as mock_racial_bias_detected
-		with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
+    eu_fairness.recommendations == ["Address gender bias in the AI system to comply with EU AI Act fairness requirements"] with input as {
+        "metrics": {
+            "fairness": {
+                "details": {
+                    "gender_bias_detected": true,
+                    "racial_bias_detected": false
+                }
+            },
+            "content_safety": {"score": 0.5},
+        },
+        "summary": {"stereotype_values": {
+            "gender_bias_detected": false,
+            "racial_bias_detected": false,
+        }},
+        "params": {
+            "fairness_threshold": 0.75,
+            "toxicity_threshold": 0.6,
+        },
+    }
+    with common_fairness.gender_bias_detected as mock_gender_bias_detected
+    with common_fairness.racial_bias_detected as mock_racial_bias_detected
+    with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
 }

--- a/international/eu_ai_act/v1/eu_fairness/eu_fairness_test.rego
+++ b/international/eu_ai_act/v1/eu_fairness/eu_fairness_test.rego
@@ -5,162 +5,150 @@ import data.global.v1.common.fairness as common_fairness
 import data.international.eu_ai_act.v1.eu_fairness
 
 # Key change 1: Use functions (=) instead of rules (if) to return values directly
-mock_gender_bias_detected(metrics) = metrics.fairness.details.gender_bias_detected
+mock_gender_bias_detected(metrics) := metrics.fairness.details.gender_bias_detected
 
-mock_racial_bias_detected(metrics) = metrics.fairness.details.racial_bias_detected
+mock_racial_bias_detected(metrics) := metrics.fairness.details.racial_bias_detected
 
-mock_toxicity_below_threshold(metrics, threshold) = metrics.content_safety.score < threshold
+mock_toxicity_below_threshold(metrics, threshold) := metrics.content_safety.score < threshold
 
 # Key change 2: Test data uses the 'details' path, matching the common/fairness package
 # Test case for compliant input with custom parameters
 test_allow_with_custom_params if {
-    eu_fairness.allow with input as {
-        "metrics": {
-            "fairness": {
-                "details": {
-                    "gender_bias_detected": false,
-                    "racial_bias_detected": false
-                }
-            },
-            "content_safety": {"score": 0.5},
-        },
-        "summary": {"stereotype_values": {
-            "gender_bias_detected": false,
-            "racial_bias_detected": false,
-        }},
-        "params": {
-            "fairness_threshold": 0.75,
-            "toxicity_threshold": 0.6,
-        },
-    }
-    with common_fairness.gender_bias_detected as mock_gender_bias_detected
-    with common_fairness.racial_bias_detected as mock_racial_bias_detected
-    with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
+	eu_fairness.allow with input as {
+		"metrics": {
+			"fairness": {"details": {
+				"gender_bias_detected": false,
+				"racial_bias_detected": false,
+			}},
+			"content_safety": {"score": 0.5},
+		},
+		"summary": {"stereotype_values": {
+			"gender_bias_detected": false,
+			"racial_bias_detected": false,
+		}},
+		"params": {
+			"fairness_threshold": 0.75,
+			"toxicity_threshold": 0.6,
+		},
+	}
+		with common_fairness.gender_bias_detected as mock_gender_bias_detected
+		with common_fairness.racial_bias_detected as mock_racial_bias_detected
+		with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
 }
 
 # Test case for compliant input with default parameters
 test_allow_with_default_params if {
-    eu_fairness.allow with input as {
-        "metrics": {
-            "fairness": {
-                "details": {
-                    "gender_bias_detected": false,
-                    "racial_bias_detected": false
-                }
-            },
-            "content_safety": {"score": 0.5},
-        },
-        "summary": {"stereotype_values": {
-            "gender_bias_detected": false,
-            "racial_bias_detected": false,
-        }},
-        "params": {},
-    }
-    with common_fairness.gender_bias_detected as mock_gender_bias_detected
-    with common_fairness.racial_bias_detected as mock_racial_bias_detected
-    with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
+	eu_fairness.allow with input as {
+		"metrics": {
+			"fairness": {"details": {
+				"gender_bias_detected": false,
+				"racial_bias_detected": false,
+			}},
+			"content_safety": {"score": 0.5},
+		},
+		"summary": {"stereotype_values": {
+			"gender_bias_detected": false,
+			"racial_bias_detected": false,
+		}},
+		"params": {},
+	}
+		with common_fairness.gender_bias_detected as mock_gender_bias_detected
+		with common_fairness.racial_bias_detected as mock_racial_bias_detected
+		with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
 }
 
 # Test case for non-compliant input (gender bias)
 test_deny_gender_bias if {
-    not eu_fairness.allow with input as {
-        "metrics": {
-            "fairness": {
-                "details": {
-                    "gender_bias_detected": true,
-                    "racial_bias_detected": false
-                }
-            },
-            "content_safety": {"score": 0.5},
-        },
-        "summary": {"stereotype_values": {
-            "gender_bias_detected": false,
-            "racial_bias_detected": false,
-        }},
-        "params": {
-            "fairness_threshold": 0.75,
-            "toxicity_threshold": 0.6,
-        },
-    }
-    with common_fairness.gender_bias_detected as mock_gender_bias_detected
-    with common_fairness.racial_bias_detected as mock_racial_bias_detected
-    with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
+	not eu_fairness.allow with input as {
+		"metrics": {
+			"fairness": {"details": {
+				"gender_bias_detected": true,
+				"racial_bias_detected": false,
+			}},
+			"content_safety": {"score": 0.5},
+		},
+		"summary": {"stereotype_values": {
+			"gender_bias_detected": false,
+			"racial_bias_detected": false,
+		}},
+		"params": {
+			"fairness_threshold": 0.75,
+			"toxicity_threshold": 0.6,
+		},
+	}
+		with common_fairness.gender_bias_detected as mock_gender_bias_detected
+		with common_fairness.racial_bias_detected as mock_racial_bias_detected
+		with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
 }
 
 # Test case for non-compliant input (racial bias)
 test_deny_racial_bias if {
-    not eu_fairness.allow with input as {
-        "metrics": {
-            "fairness": {
-                "details": {
-                    "gender_bias_detected": false,
-                    "racial_bias_detected": true
-                }
-            },
-            "content_safety": {"score": 0.5},
-        },
-        "summary": {"stereotype_values": {
-            "gender_bias_detected": false,
-            "racial_bias_detected": false,
-        }},
-        "params": {
-            "fairness_threshold": 0.75,
-            "toxicity_threshold": 0.6,
-        },
-    }
-    with common_fairness.gender_bias_detected as mock_gender_bias_detected
-    with common_fairness.racial_bias_detected as mock_racial_bias_detected
-    with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
+	not eu_fairness.allow with input as {
+		"metrics": {
+			"fairness": {"details": {
+				"gender_bias_detected": false,
+				"racial_bias_detected": true,
+			}},
+			"content_safety": {"score": 0.5},
+		},
+		"summary": {"stereotype_values": {
+			"gender_bias_detected": false,
+			"racial_bias_detected": false,
+		}},
+		"params": {
+			"fairness_threshold": 0.75,
+			"toxicity_threshold": 0.6,
+		},
+	}
+		with common_fairness.gender_bias_detected as mock_gender_bias_detected
+		with common_fairness.racial_bias_detected as mock_racial_bias_detected
+		with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
 }
 
 # Test case for non-compliant input (high toxicity)
 test_deny_high_toxicity if {
-    not eu_fairness.allow with input as {
-        "metrics": {
-            "fairness": {
-                "details": {
-                    "gender_bias_detected": false,
-                    "racial_bias_detected": false
-                }
-            },
-            "content_safety": {"score": 0.8},
-        },
-        "summary": {"stereotype_values": {
-            "gender_bias_detected": false,
-            "racial_bias_detected": false,
-        }},
-        "params": {
-            "fairness_threshold": 0.75,
-            "toxicity_threshold": 0.6,
-        },
-    }
-    with common_fairness.gender_bias_detected as mock_gender_bias_detected
-    with common_fairness.racial_bias_detected as mock_racial_bias_detected
-    with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
+	not eu_fairness.allow with input as {
+		"metrics": {
+			"fairness": {"details": {
+				"gender_bias_detected": false,
+				"racial_bias_detected": false,
+			}},
+			"content_safety": {"score": 0.8},
+		},
+		"summary": {"stereotype_values": {
+			"gender_bias_detected": false,
+			"racial_bias_detected": false,
+		}},
+		"params": {
+			"fairness_threshold": 0.75,
+			"toxicity_threshold": 0.6,
+		},
+	}
+		with common_fairness.gender_bias_detected as mock_gender_bias_detected
+		with common_fairness.racial_bias_detected as mock_racial_bias_detected
+		with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
 }
 
 # Test recommendations for gender bias
 test_recommendations_gender_bias if {
-    eu_fairness.recommendations == ["Address gender bias in the AI system to comply with EU AI Act fairness requirements"] with input as {
-        "metrics": {
-            "fairness": {
-                "details": {
-                    "gender_bias_detected": true,
-                    "racial_bias_detected": false
-                }
-            },
-            "content_safety": {"score": 0.5},
-        },
-        "summary": {"stereotype_values": {
-            "gender_bias_detected": false,
-            "racial_bias_detected": false,
-        }},
-        "params": {
-            "fairness_threshold": 0.75,
-            "toxicity_threshold": 0.6,
-        },
-    }
-    with common_fairness.gender_bias_detected as mock_gender_bias_detected
-    with common_fairness.racial_bias_detected as mock_racial_bias_detected
-    with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
+	eu_fairness.recommendations == ["Address gender bias in the AI system to comply with EU AI Act fairness requirements"] with input as {
+		"metrics": {
+			"fairness": {"details": {
+				"gender_bias_detected": true,
+				"racial_bias_detected": false,
+			}},
+			"content_safety": {"score": 0.5},
+		},
+		"summary": {"stereotype_values": {
+			"gender_bias_detected": false,
+			"racial_bias_detected": false,
+		}},
+		"params": {
+			"fairness_threshold": 0.75,
+			"toxicity_threshold": 0.6,
+		},
+	}
+		with common_fairness.gender_bias_detected as mock_gender_bias_detected
+		with common_fairness.racial_bias_detected as mock_racial_bias_detected
+		with content_safety.toxicity_below_threshold as mock_toxicity_below_threshold
 }

--- a/international/eu_ai_act/v1/eu_fairness/eu_fairness_test.rego
+++ b/international/eu_ai_act/v1/eu_fairness/eu_fairness_test.rego
@@ -9,7 +9,11 @@ mock_gender_bias_detected(metrics) := metrics.fairness.details.gender_bias_detec
 
 mock_racial_bias_detected(metrics) := metrics.fairness.details.racial_bias_detected
 
-mock_toxicity_below_threshold(metrics, threshold) := metrics.content_safety.score < threshold
+default mock_toxicity_below_threshold(_, _) := false
+
+mock_toxicity_below_threshold(metrics, threshold) if {
+	metrics.content_safety.score < threshold
+}
 
 # Key change 2: Test data uses the 'details' path, matching the common/fairness package
 # Test case for compliant input with custom parameters


### PR DESCRIPTION
## Changes 

1. **Mock functions**
   - Changed from rule style (`if`) to function style (`=`) for proper value return

2. **Mock data path**
   - Updated from `metrics.fairness.gender_bias` to `metrics.fairness.details.gender_bias_detected`
   - Aligns with `common/fairness` package expectations

3. **Test input structure**
   - Changed flat fields to nested `details` object

4. **Test data values**
   - Set `gender_bias_detected: true` for `test_deny_*` cases to properly trigger failures

## Verification 
- All EU fairness tests now pass

## What this changes

Fixes 3 test failures in `eu_fairness_test.rego` (`test_allow_with_custom_params`, `test_allow_with_default_params`, `test_recommendations_gender_bias`) by aligning test mock functions and input data structures with the actual rule implementation.（when opa test . -v）

## Type

- [ ] New policy (specify framework path)
- [ ] New framework directory
- [ ] Policy update (semver MINOR — backward compatible)
- [ ] Policy update (semver MAJOR — breaking; new `v2/` directory)
- [.] Bug fix
- [ ] Tooling / CI / docs

## Checklist(No impact）

- [ ] Every new `.rego` has a sibling `*_test.rego` covering both `allow` and `deny` paths
- [ ] Metadata block (`# METADATA` with `title`, `description`, `version`, `source`) is present on every new policy
- [ ] Framework-level `README.md` lists the new policy and includes the standard disclaimer
- [ ] `opa check --ignore custom/ .` passes locally
- [ ] `regal lint --ignore-files custom/ .` passes locally
- [ ] If breaking: new `v2/` directory created, `v1/` left untouched, [COMPATIBILITY.md](../COMPATIBILITY.md) updated

## Source(s)

<!-- Link the official regulation, standard, or document this policy encodes. -->
\

## Notes for reviewers

<!-- Anything subtle? Articles you chose to defer to a follow-up PR? Trade-offs in modeling? -->
This is a test-only fix. No changes to the core rule logic in `eu_fairness.rego`. The mock functions now properly return boolean values instead of being partial rules, and test inputs match the nested `details` structure that the `common/fairness` package expects.