### PR TITLE
fix(diagnostic_safety): align field names with test expectations

### DIFF
--- a/industry_specific/healthcare/v1/diagnostic_safety/diagnostic_safety.rego
+++ b/industry_specific/healthcare/v1/diagnostic_safety/diagnostic_safety.rego
@@ -16,27 +16,27 @@ import data.global.v1.common.risk_management
 
 # Define helper rules to check which evaluations failed/passed
 fairness_eval_fails if {
-	input.evaluation.fairness.score < object.get(input.params, "fairness_threshold", 0.85)
+	input.evaluation.fairness_score < object.get(input.params, "fairness_threshold", 0.85)
 }
 
 content_safety_eval_fails if {
-	input.evaluation.content_safety.score < object.get(input.params, "content_safety_threshold", 0.90)
+	input.evaluation.content_safety_score < object.get(input.params, "content_safety_threshold", 0.90)
 }
 
 risk_management_eval_fails if {
-	input.evaluation.risk_management.score < object.get(input.params, "risk_management_threshold", 0.90)
+	input.evaluation.risk_management_score < object.get(input.params, "risk_management_threshold", 0.90)
 }
 
 fairness_passes if {
-	input.evaluation.fairness.score >= object.get(input.params, "fairness_threshold", 0.85)
+	input.evaluation.fairness_score >= object.get(input.params, "fairness_threshold", 0.85)
 }
 
 content_safety_passes if {
-	input.evaluation.content_safety.score >= object.get(input.params, "content_safety_threshold", 0.90)
+	input.evaluation.content_safety_score >= object.get(input.params, "content_safety_threshold", 0.90)
 }
 
 risk_management_passes if {
-	input.evaluation.risk_management.score >= object.get(input.params, "risk_management_threshold", 0.90)
+	input.evaluation.risk_management_score >= object.get(input.params, "risk_management_threshold", 0.90)
 }
 
 # Create individual arrays based on evaluation results


### PR DESCRIPTION
## Problem
Rules used nested `.score` fields (`evaluation.fairness.score`), but tests provided flat `_score` fields (`evaluation.fairness_score`).

## Fix 
Changed all `.score` to `_score` in `diagnostic_safety.rego`:
- `evaluation.fairness.score` → `evaluation.fairness_score`
- `evaluation.content_safety.score` → `evaluation.content_safety_score`
- `evaluation.risk_management.score` → `evaluation.risk_management_score`

## Verification
- All diagnostic_safety tests now pass

## What this changes
<!-- One or two sentences. -->
Aligns field names between rule implementation and test data; no behavioral change, purely a bug fix.

## Type

- [ ] New policy (specify framework path)
- [ ] New framework directory
- [ ] Policy update (semver MINOR — backward compatible)
- [ ] Policy update (semver MAJOR — breaking; new `v2/` directory)
- [.] Bug fix
- [ ] Tooling / CI / docs

## Checklist(no impact)

- [ ] Every new `.rego` has a sibling `*_test.rego` covering both `allow` and `deny` paths
- [ ] Metadata block (`# METADATA` with `title`, `description`, `version`, `source`) is present on every new policy
- [ ] Framework-level `README.md` lists the new policy and includes the standard disclaimer
- [ ] `opa check --ignore custom/ .` passes locally
- [ ] `regal lint --ignore-files custom/ .` passes locally
- [ ] If breaking: new `v2/` directory created, `v1/` left untouched, [COMPATIBILITY.md](../COMPATIBILITY.md) updated

## Source(s)

<!-- Link the official regulation, standard, or document this policy encodes. -->

## Notes for reviewers

<!-- Anything subtle? Articles you chose to defer to a follow-up PR? Trade-offs in modeling? -->
This is a straightforward field name alignment fix. The `compliance_report` already used `_score` format correctly, so no changes needed there.