### PR TITLE
fix(vehicle_safety): satisfy regal's unassigned-return-value rule

### DIFF
--- a/industry_specific/automotive/v1/vehicle_safety/vehicle_safety.rego
+++ b/industry_specific/automotive/v1/vehicle_safety/vehicle_safety.rego
@@ -26,7 +26,7 @@ hara_analysis_is_compliant if {
 
 # Automotive Safety Integrity Level (ASIL) Determination
 asil_determination_is_compliant if {
-	object.get(input.safety_assessment, "asil_determination", false)
+	object.get(input.safety_assessment, "asil_determination", false) != false
 	is_object(input.safety_assessment.asil_determination)
 	input.safety_assessment.asil_determination.status == "completed"
 	is_string(input.safety_assessment.asil_determination.final_asil_level)
@@ -35,7 +35,7 @@ asil_determination_is_compliant if {
 
 # Safety of the Intended Functionality (SOTIF) Analysis
 sotif_analysis_is_compliant if {
-	object.get(input.safety_assessment, "sotif_analysis", false)
+	object.get(input.safety_assessment, "sotif_analysis", false) != false
 	is_object(input.safety_assessment.sotif_analysis)
 	input.safety_assessment.sotif_analysis.status == "completed"
 	count(input.safety_assessment.sotif_analysis.scenarios_analyzed) > 0
@@ -43,12 +43,12 @@ sotif_analysis_is_compliant if {
 
 # Operational Design Domain (ODD) Definition
 odd_definition_is_compliant if {
-	object.get(input.safety_assessment, "odd_definition", false)
+	object.get(input.safety_assessment, "odd_definition", false) != false
 	is_object(input.safety_assessment.odd_definition)
 	input.safety_assessment.odd_definition.status == "defined"
-	object.get(input.safety_assessment.odd_definition.conditions, "road_types", false)
-	object.get(input.safety_assessment.odd_definition.conditions, "weather", false)
-	object.get(input.safety_assessment.odd_definition.conditions, "traffic", false)
+	object.get(input.safety_assessment.odd_definition.conditions, "road_types", false) != false
+	object.get(input.safety_assessment.odd_definition.conditions, "weather", false) != false
+	object.get(input.safety_assessment.odd_definition.conditions, "traffic", false) != false
 }
 
 # Deny rule with detailed messages


### PR DESCRIPTION
## What

Fixes 6 Regal violations in `industry_specific/automotive/v1/vehicle_safety/vehicle_safety.rego` that currently fail `regal lint --ignore-files custom/ .` on `main`.

## Why this matters right now

CI installs Regal's latest release on every run. A newer version added the `unassigned-return-value` rule, which now flags this file's `object.get(input.x, "key", false)` pattern used as a bare existence check (its return isn't guaranteed boolean, so an unassigned use is ambiguous style). That means **regal lint is currently red on `main`**, so every open and future PR shows a failing check regardless of what it touches — I hit this directly while reviewing #32.

## Fix

Made the boolean check explicit: `object.get(..., false) != false` instead of the bare call. Same semantics (checks the key is present and not the `false` sentinel), just satisfies the rule.

## Verification

- `opa check --ignore custom/ .` — pass
- `regal lint --ignore-files custom/ .` — **0 violations** (was 6)
- `opa test ./industry_specific/automotive/v1/vehicle_safety/` — 2/2 pass, unchanged
- `opa fmt --diff` — no diff

## Note for a follow-up

While verifying this, I found the CI workflow only runs `opa check` and `regal lint`, never `opa test` — and a full `opa test .` run on `main` currently shows 10 pre-existing failures in `healthcare/diagnostic_safety` and `nist/ai_600_1`, unrelated to this change. Since they don't fail CI today, they've been silent. Flagging separately rather than bundling a fix here — happy to open a follow-up issue/PR if useful.