### PR TITLE
feat(aviation): implement real ICAO/FAA/EASA/RTCA/ISO and aviation-vertical policies (completes GOP-2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file is the canonical operational guide for AI coding agents working in thi
 
 ## What this project is
 
-**GOPAL** (Governance Open Policy Agent Library) is a curated set of [OPA](https://www.openpolicyagent.org/) Rego policies encoding real-world AI-governance requirements — the EU AI Act, NIST AI RMF, FERPA/COPPA in education, fair-lending rules, and more.
+**GOPAL** (Governance Open Policy Agent Library) is a curated set of [OPA](https://www.openpolicyagent.org/) Rego policies encoding real-world AI-governance requirements — the EU AI Act, NIST AI RMF, aviation safety standards, FERPA/COPPA in education, fair-lending rules, and more.
 
 It is consumable two ways:
 
@@ -20,9 +20,12 @@ gopal/
 │   ├── eu_ai_act/v1/         29 policies — EU AI Act 2024/1689
 │   ├── nist/v1/              NIST AI RMF + AI 600-1
 │   ├── india/v1/             India Digital Policy
-│   └── brazil/v1/            Brazil AI Governance Bill
+│   ├── brazil/v1/            Brazil AI Governance Bill
+│   ├── icao/, faa/, easa/    Aviation regulators
+│   └── standards/v1/         RTCA DO-365, ISO 21384
 ├── industry_specific/
 │   ├── education/v1/         12 policies — FERPA, COPPA, proctoring, grading
+│   ├── aviation/v1/          12 policies — airworthiness, autonomy, data, ops
 │   ├── healthcare/v1/        Patient & diagnostic safety
 │   ├── bfs/v1/               Model risk, fair lending
 │   └── automotive/v1/        Vehicle safety integration
@@ -34,7 +37,7 @@ gopal/
 └── .github/workflows/        OPA + Regal CI
 ```
 
-**66 production policies. 86 Rego files including tests.**
+**85 production policies. 124 Rego files including tests.**
 
 ## Useful commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## What you're working on
 
-**GOPAL** is a 66-policy Rego library for AI compliance. The user evaluates inputs (model cards, AI-system metadata, eval results) against named regulations (EU AI Act, NIST RMF, FERPA/COPPA, etc.) and gets back structured compliance verdicts.
+**GOPAL** is an 85-policy Rego library for AI compliance. The user evaluates inputs (model cards, AI-system metadata, eval results) against named regulations (EU AI Act, NIST RMF, aviation standards, FERPA/COPPA, etc.) and gets back structured compliance verdicts.
 
 ## Fast orientation
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -16,7 +16,7 @@
 
 ## What you're working on
 
-**GOPAL** is a 66-policy Rego library for AI compliance covering EU AI Act, NIST RMF, FERPA/COPPA, fair lending, and more. See [README.md](README.md) for the full coverage table and [AGENTS.md](AGENTS.md) for the authoring conventions.
+**GOPAL** is an 85-policy Rego library for AI compliance covering EU AI Act, NIST RMF, aviation standards, FERPA/COPPA, fair lending, and more. See [README.md](README.md) for the full coverage table and [AGENTS.md](AGENTS.md) for the authoring conventions.
 
 ## Quick reference (Rego policy authoring)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <em>AI compliance rules you can read, run, diff, and prove.</em>
 </p>
 <p align="center">
-  <sub>66 policies · 4 international frameworks · 4 industry verticals</sub>
+  <sub>85 policies · 8 international frameworks · 5 industry verticals</sub>
 </p>
 
 <p align="center">
@@ -27,8 +27,8 @@
   <a href="https://www.openpolicyagent.org/"><img src="https://img.shields.io/badge/OPA-latest-blue.svg?style=flat-square" alt="OPA"></a>
   <a href="https://github.com/StyraInc/regal"><img src="https://img.shields.io/badge/lint-regal-yellow.svg?style=flat-square" alt="Regal"></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square" alt="Apache 2.0"></a>
-  <img src="https://img.shields.io/badge/policies-66-orange.svg?style=flat-square" alt="66 Policies">
-  <img src="https://img.shields.io/badge/frameworks-4-purple.svg?style=flat-square" alt="4 Frameworks">
+  <img src="https://img.shields.io/badge/policies-85-orange.svg?style=flat-square" alt="85 Policies">
+  <img src="https://img.shields.io/badge/frameworks-8-purple.svg?style=flat-square" alt="8 Frameworks">
   <a href="https://makeapullrequest.com"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square" alt="PRs Welcome"></a>
 </p>
 
@@ -36,14 +36,14 @@
 
 **GOPAL: Governance Open Policy Agent Library.** Think of it as an open policy pack for AI regulation.
 
-A curated collection of [OPA](https://www.openpolicyagent.org/) policies, written in Rego, that encode real AI-governance requirements: the EU AI Act, NIST AI RMF, FERPA/COPPA in education, fair-lending rules in banking, and more.
+A curated collection of [OPA](https://www.openpolicyagent.org/) policies, written in Rego, that encode real AI-governance requirements: the EU AI Act, NIST AI RMF, aviation safety standards, FERPA/COPPA in education, fair-lending rules in banking, and more.
 
 Run them against your AI system's metadata, model cards, or evaluation results — and get back a structured, machine-readable compliance verdict you can drop into CI, an audit log, or a regulator submission.
 
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="diagrams/diagram1_hero_numbers_dark.svg">
-    <img src="diagrams/diagram1_hero_numbers_light.svg" alt="GOPAL coverage: 66 policies across international standards, industry verticals, and cross-cutting principles" width="85%" />
+    <img src="diagrams/diagram1_hero_numbers_light.svg" alt="GOPAL coverage: 85 policies across international standards, aviation, industry verticals, and cross-cutting principles" width="85%" />
   </picture>
 </p>
 
@@ -51,7 +51,7 @@ Run them against your AI system's metadata, model cards, or evaluation results �
 
 ## AI compliance rules you can read, run, diff, and prove
 
-GOPAL turns regulatory and governance requirements — the EU AI Act, NIST AI RMF, FERPA/COPPA, fair lending, and healthcare safety — into executable OPA policies.
+GOPAL turns regulatory and governance requirements — the EU AI Act, NIST AI RMF, aviation safety standards, FERPA/COPPA, fair lending, and healthcare safety — into executable OPA policies.
 
 Use GOPAL when you want AI governance checks that are:
 
@@ -144,7 +144,7 @@ If you already run OPA for Kubernetes admission, cloud authorization, CI/CD, or 
 
 The packages, conventions, and test patterns are idiomatic Rego — no DSL on top, no Python required to evaluate. You can:
 
-- pull individual frameworks (`international/eu_ai_act/v1/`, `industry_specific/healthcare/v1/`) into a bundle
+- pull individual frameworks (`international/eu_ai_act/v1/`, `industry_specific/aviation/v1/`) into a bundle
 - evaluate with `opa eval`, [Conftest](https://www.conftest.dev/), or your existing OPA server
 - pin to a major version (`v1/`) and review upgrades as PRs
 - compose GOPAL rules with your private `custom/` rules in the same evaluation
@@ -169,10 +169,15 @@ gopal/
 │   ├── eu_ai_act/v1/         29 policies — EU AI Act 2024/1689
 │   ├── nist/v1/              5  policies — NIST AI RMF + AI 600-1
 │   ├── india/v1/             1  policy   — Digital India Policy
-│   └── brazil/v1/            1  policy   — AI Governance Bill
+│   ├── brazil/v1/            1  policy   — AI Governance Bill
+│   ├── icao/v1/              1  policy   — ICAO Doc 10019
+│   ├── faa/v1/               2  policies — Part 107, Remote ID
+│   ├── easa/v1/              2  policies — Regulation 2019/947, SORA
+│   └── standards/v1/         2  policies — RTCA DO-365, ISO 21384
 │
 ├── industry_specific/    Vertical-specific requirements
 │   ├── education/v1/         12 policies — FERPA, COPPA, proctoring, grading
+│   ├── aviation/v1/          12 policies — airworthiness, autonomy, data, ops
 │   ├── healthcare/v1/         2 policies — patient & diagnostic safety
 │   ├── bfs/v1/                2 policies — model risk, fair lending
 │   └── automotive/v1/         1 policy   — vehicle safety integration
@@ -193,7 +198,7 @@ gopal/
 └── custom/               Your private policies (git-ignored, CI-skipped)
 ```
 
-**66 production policies. 86 Rego files including tests.**
+**85 production policies. 124 Rego files including tests.**
 
 ---
 
@@ -204,14 +209,15 @@ gopal/
 | Targets AI systems specifically | ✅ | ❌ | ✅ |
 | Open source (Apache 2.0) | ✅ | ✅ | ❌ |
 | You can read every rule | ✅ Rego | ✅ Rego | ❌ Hidden |
-| Tracks named regulations (EU AI Act, NIST RMF, FERPA/COPPA) | ✅ 6+ | ❌ | Partial |
-| Industry-specific verticals out of the box | ✅ 4 | ❌ | Limited |
+| Tracks named regulations (EU AI Act, NIST RMF, FAA) | ✅ 10+ | ❌ | Partial |
+| Industry-specific verticals out of the box | ✅ 5 | ❌ | Limited |
+| Aviation / safety-critical coverage | ✅ ICAO, RTCA, FAA, EASA, ISO | ❌ | ❌ |
 | Education sector (FERPA / COPPA) | ✅ | ❌ | Rare |
 | Versioned policies (`v1/`, `v2/` …) | ✅ Semver | Varies | N/A |
 | CI/CD integration | ✅ `opa check` + Regal | ✅ | Varies |
 | Custom local policies (not shared upstream) | ✅ `custom/` is git-ignored | ❌ | Paid tier |
 
-A few other open-source projects worth knowing about: [VerifyWise](https://github.com/verifywise-ai/verifywise) and [Compl-AI](https://github.com/compl-ai/compl-ai) both evaluate AI systems against the EU AI Act and other frameworks. [airblackbox](https://github.com/airblackbox) scans agent frameworks like LangChain, CrewAI, and AutoGen for compliance gaps at runtime. GOPAL's difference is that it's plain Rego/OPA, so it slots into policy tooling you may already run for Kubernetes or cloud authorization, and it isn't limited to the EU AI Act. Education and banking frameworks are in the same tree, all versioned and tested the same way.
+A few other open-source projects worth knowing about: [VerifyWise](https://github.com/verifywise-ai/verifywise) and [Compl-AI](https://github.com/compl-ai/compl-ai) both evaluate AI systems against the EU AI Act and other frameworks. [airblackbox](https://github.com/airblackbox) scans agent frameworks like LangChain, CrewAI, and AutoGen for compliance gaps at runtime. GOPAL's difference is that it's plain Rego/OPA, so it slots into policy tooling you may already run for Kubernetes or cloud authorization, and it isn't limited to the EU AI Act. Aviation, education, and banking frameworks are in the same tree, all versioned and tested the same way.
 
 ---
 
@@ -325,7 +331,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the PR workflow.
 - **UK AI regulation principles** — pro-innovation framework rules
 - **California SB-1047 successor** — when finalized
 - **MAS / HKMA banking AI guidance** — APAC financial supervision
-- **Aviation AI/UAS safety** — ICAO, FAA, EASA, and industry-vertical policies are drafted on a feature branch (detect & avoid, certification, airworthiness) but not yet merged: they're missing test coverage, which this project requires for every policy before it ships
 
 Open an issue if there's a framework you need.
 

--- a/diagrams/diagram1_hero_numbers_dark.svg
+++ b/diagrams/diagram1_hero_numbers_dark.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg viewBox="0 0 680 450" xmlns="http://www.w3.org/2000/svg" role="img" font-family="system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
 <title>GOPAL coverage</title>
-<desc>66 production Rego policies across 4 frameworks and 4 industries.</desc>
+<desc>85 production Rego policies across 8 frameworks and 5 industries.</desc>
 
-<text x="170" y="60" font-size="36" font-weight="500" fill="#fbbf24" text-anchor="middle">66</text>
+<text x="170" y="60" font-size="36" font-weight="500" fill="#fbbf24" text-anchor="middle">85</text>
 <text x="170" y="80" font-size="12" fill="#8b949e" text-anchor="middle">Rego policies</text>
-<text x="340" y="60" font-size="36" font-weight="500" fill="#fbbf24" text-anchor="middle">4</text>
+<text x="340" y="60" font-size="36" font-weight="500" fill="#fbbf24" text-anchor="middle">8</text>
 <text x="340" y="80" font-size="12" fill="#8b949e" text-anchor="middle">frameworks</text>
-<text x="510" y="60" font-size="36" font-weight="500" fill="#fbbf24" text-anchor="middle">4</text>
+<text x="510" y="60" font-size="36" font-weight="500" fill="#fbbf24" text-anchor="middle">5</text>
 <text x="510" y="80" font-size="12" fill="#8b949e" text-anchor="middle">industries</text>
 
 <line x1="40" y1="98" x2="640" y2="98" stroke="#30363d" stroke-width="0.5"/>
@@ -30,14 +30,14 @@
 <rect x="350" y="110" width="308" height="150" rx="10" fill="#161b22" stroke="#30363d"/>
 <rect x="350" y="110" width="308" height="4" fill="#6366f1"/>
 <g transform="translate(374, 128)" fill="none" stroke="#a5b4fc" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-<line x1="2" y1="8" x2="14" y2="8"/><path d="M9 3 L14 8 L9 13"/>
+<path d="M14 1 L2 9 L9 11 L11 14 Z"/><line x1="9" y1="11" x2="14" y2="1"/>
 </g>
-<text x="398" y="142" font-size="14" font-weight="500" fill="#f0f6fc">On the roadmap</text>
+<text x="398" y="142" font-size="14" font-weight="500" fill="#f0f6fc">Aviation (19 policies)</text>
 <line x1="374" y1="156" x2="634" y2="156" stroke="#21262d" stroke-width="1"/>
-<circle cx="380" cy="172" r="2.5" fill="#818cf8"/><text x="390" y="176" font-size="12" fill="#c9d1d9">Aviation AI/UAS safety — ICAO, FAA, EASA</text>
-<circle cx="380" cy="192" r="2.5" fill="#818cf8"/><text x="390" y="196" font-size="12" fill="#c9d1d9">UK AI regulation principles</text>
-<circle cx="380" cy="212" r="2.5" fill="#818cf8"/><text x="390" y="216" font-size="12" fill="#c9d1d9">California SB-1047 successor</text>
-<circle cx="380" cy="232" r="2.5" fill="#818cf8"/><text x="390" y="236" font-size="12" fill="#c9d1d9">MAS / HKMA banking AI guidance</text>
+<circle cx="380" cy="172" r="2.5" fill="#818cf8"/><text x="390" y="176" font-size="12" fill="#c9d1d9">ICAO Doc 10019</text>
+<circle cx="380" cy="192" r="2.5" fill="#818cf8"/><text x="390" y="196" font-size="12" fill="#c9d1d9">FAA Part 107, Remote ID</text>
+<circle cx="380" cy="212" r="2.5" fill="#818cf8"/><text x="390" y="216" font-size="12" fill="#c9d1d9">EASA Reg 2019/947, SORA</text>
+<circle cx="380" cy="232" r="2.5" fill="#818cf8"/><text x="390" y="236" font-size="12" fill="#c9d1d9">RTCA DO-365, ISO 21384</text>
 </g>
 
 <g>
@@ -46,12 +46,12 @@
 <g transform="translate(46, 298)" fill="none" stroke="#a5b4fc" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
 <rect x="2" y="5" width="12" height="10"/><line x1="5" y1="8" x2="5" y2="13"/><line x1="8" y1="8" x2="8" y2="13"/><line x1="11" y1="8" x2="11" y2="13"/>
 </g>
-<text x="70" y="312" font-size="14" font-weight="500" fill="#f0f6fc">Industry verticals (17)</text>
+<text x="70" y="312" font-size="14" font-weight="500" fill="#f0f6fc">Industry verticals (29)</text>
 <line x1="46" y1="326" x2="306" y2="326" stroke="#21262d" stroke-width="1"/>
 <circle cx="52" cy="342" r="2.5" fill="#818cf8"/><text x="62" y="346" font-size="12" fill="#c9d1d9">Education (12) — FERPA, COPPA</text>
-<circle cx="52" cy="362" r="2.5" fill="#818cf8"/><text x="62" y="366" font-size="12" fill="#c9d1d9">Healthcare — patient safety</text>
+<circle cx="52" cy="362" r="2.5" fill="#818cf8"/><text x="62" y="366" font-size="12" fill="#c9d1d9">Aviation (12) — airworthiness, ops</text>
 <circle cx="52" cy="382" r="2.5" fill="#818cf8"/><text x="62" y="386" font-size="12" fill="#c9d1d9">Banking — model risk, fair lending</text>
-<circle cx="52" cy="402" r="2.5" fill="#818cf8"/><text x="62" y="406" font-size="12" fill="#c9d1d9">Automotive — vehicle safety</text>
+<circle cx="52" cy="402" r="2.5" fill="#818cf8"/><text x="62" y="406" font-size="12" fill="#c9d1d9">Healthcare, automotive — safety</text>
 </g>
 
 <g>

--- a/diagrams/diagram1_hero_numbers_light.svg
+++ b/diagrams/diagram1_hero_numbers_light.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg viewBox="0 0 680 450" xmlns="http://www.w3.org/2000/svg" role="img" font-family="system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
 <title>GOPAL coverage</title>
-<desc>66 production Rego policies across 4 frameworks and 4 industries.</desc>
+<desc>85 production Rego policies across 8 frameworks and 5 industries.</desc>
 
-<text x="170" y="60" font-size="36" font-weight="500" fill="#d97706" text-anchor="middle">66</text>
+<text x="170" y="60" font-size="36" font-weight="500" fill="#d97706" text-anchor="middle">85</text>
 <text x="170" y="80" font-size="12" fill="#64748b" text-anchor="middle">Rego policies</text>
-<text x="340" y="60" font-size="36" font-weight="500" fill="#d97706" text-anchor="middle">4</text>
+<text x="340" y="60" font-size="36" font-weight="500" fill="#d97706" text-anchor="middle">8</text>
 <text x="340" y="80" font-size="12" fill="#64748b" text-anchor="middle">frameworks</text>
-<text x="510" y="60" font-size="36" font-weight="500" fill="#d97706" text-anchor="middle">4</text>
+<text x="510" y="60" font-size="36" font-weight="500" fill="#d97706" text-anchor="middle">5</text>
 <text x="510" y="80" font-size="12" fill="#64748b" text-anchor="middle">industries</text>
 
 <line x1="40" y1="98" x2="640" y2="98" stroke="#e2e8f0" stroke-width="0.5"/>
@@ -30,14 +30,14 @@
 <rect x="350" y="110" width="308" height="150" rx="10" fill="#ffffff" stroke="#e2e8f0"/>
 <rect x="350" y="110" width="308" height="4" fill="#4f46e5"/>
 <g transform="translate(374, 128)" fill="none" stroke="#4f46e5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-<line x1="2" y1="8" x2="14" y2="8"/><path d="M9 3 L14 8 L9 13"/>
+<path d="M14 1 L2 9 L9 11 L11 14 Z"/><line x1="9" y1="11" x2="14" y2="1"/>
 </g>
-<text x="398" y="142" font-size="14" font-weight="500" fill="#0f172a">On the roadmap</text>
+<text x="398" y="142" font-size="14" font-weight="500" fill="#0f172a">Aviation (19 policies)</text>
 <line x1="374" y1="156" x2="634" y2="156" stroke="#f1f5f9" stroke-width="1"/>
-<circle cx="380" cy="172" r="2.5" fill="#4f46e5"/><text x="390" y="176" font-size="12" fill="#334155">Aviation AI/UAS safety — ICAO, FAA, EASA</text>
-<circle cx="380" cy="192" r="2.5" fill="#4f46e5"/><text x="390" y="196" font-size="12" fill="#334155">UK AI regulation principles</text>
-<circle cx="380" cy="212" r="2.5" fill="#4f46e5"/><text x="390" y="216" font-size="12" fill="#334155">California SB-1047 successor</text>
-<circle cx="380" cy="232" r="2.5" fill="#4f46e5"/><text x="390" y="236" font-size="12" fill="#334155">MAS / HKMA banking AI guidance</text>
+<circle cx="380" cy="172" r="2.5" fill="#4f46e5"/><text x="390" y="176" font-size="12" fill="#334155">ICAO Doc 10019</text>
+<circle cx="380" cy="192" r="2.5" fill="#4f46e5"/><text x="390" y="196" font-size="12" fill="#334155">FAA Part 107, Remote ID</text>
+<circle cx="380" cy="212" r="2.5" fill="#4f46e5"/><text x="390" y="216" font-size="12" fill="#334155">EASA Reg 2019/947, SORA</text>
+<circle cx="380" cy="232" r="2.5" fill="#4f46e5"/><text x="390" y="236" font-size="12" fill="#334155">RTCA DO-365, ISO 21384</text>
 </g>
 
 <g>
@@ -46,12 +46,12 @@
 <g transform="translate(46, 298)" fill="none" stroke="#4f46e5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
 <rect x="2" y="5" width="12" height="10"/><line x1="5" y1="8" x2="5" y2="13"/><line x1="8" y1="8" x2="8" y2="13"/><line x1="11" y1="8" x2="11" y2="13"/>
 </g>
-<text x="70" y="312" font-size="14" font-weight="500" fill="#0f172a">Industry verticals (17)</text>
+<text x="70" y="312" font-size="14" font-weight="500" fill="#0f172a">Industry verticals (29)</text>
 <line x1="46" y1="326" x2="306" y2="326" stroke="#f1f5f9" stroke-width="1"/>
 <circle cx="52" cy="342" r="2.5" fill="#4f46e5"/><text x="62" y="346" font-size="12" fill="#334155">Education (12) — FERPA, COPPA</text>
-<circle cx="52" cy="362" r="2.5" fill="#4f46e5"/><text x="62" y="366" font-size="12" fill="#334155">Healthcare — patient safety</text>
+<circle cx="52" cy="362" r="2.5" fill="#4f46e5"/><text x="62" y="366" font-size="12" fill="#334155">Aviation (12) — airworthiness, ops</text>
 <circle cx="52" cy="382" r="2.5" fill="#4f46e5"/><text x="62" y="386" font-size="12" fill="#334155">Banking — model risk, fair lending</text>
-<circle cx="52" cy="402" r="2.5" fill="#4f46e5"/><text x="62" y="406" font-size="12" fill="#334155">Automotive — vehicle safety</text>
+<circle cx="52" cy="402" r="2.5" fill="#4f46e5"/><text x="62" y="406" font-size="12" fill="#334155">Healthcare, automotive — safety</text>
 </g>
 
 <g>

--- a/diagrams/diagram2_directory_tree_dark.svg
+++ b/diagrams/diagram2_directory_tree_dark.svg
@@ -10,12 +10,16 @@
 <path d="M2 4 H7 L9 6 H18 V18 H2 Z"/>
 </g>
 <text x="70" y="48" font-size="14" font-weight="500" fill="#f0f6fc" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">international/</text>
-<text x="266" y="48" font-size="12" fill="#8b949e">36 policies · 4 frameworks</text>
+<text x="266" y="48" font-size="12" fill="#8b949e">43 policies · 8 frameworks</text>
 <g font-size="11" fill="#c9d1d9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
 <text x="70" y="72">eu_ai_act/v1/ (29)</text>
 <text x="220" y="72">nist/v1/ (5)</text>
 <text x="320" y="72">india/v1/ (1)</text>
 <text x="410" y="72">brazil/v1/ (1)</text>
+<text x="70" y="90">icao/v1/ (1)</text>
+<text x="220" y="90">faa/v1/ (2)</text>
+<text x="320" y="90">easa/v1/ (2)</text>
+<text x="410" y="90">standards/v1/ (2)</text>
 </g>
 </g>
 
@@ -26,10 +30,11 @@
 <path d="M2 4 H7 L9 6 H18 V18 H2 Z"/>
 </g>
 <text x="70" y="144" font-size="14" font-weight="500" fill="#f0f6fc" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">industry_specific/</text>
-<text x="266" y="144" font-size="12" fill="#8b949e">17 policies · 4 verticals</text>
+<text x="266" y="144" font-size="12" fill="#8b949e">29 policies · 5 verticals</text>
 <g font-size="11" fill="#c9d1d9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
 <text x="70" y="168">education/v1/ (12)</text>
-<text x="220" y="168">healthcare/v1/ (2)</text>
+<text x="220" y="168">aviation/v1/ (12)</text>
+<text x="370" y="168">healthcare/v1/ (2)</text>
 <text x="70" y="186">bfs/v1/ (2)</text>
 <text x="220" y="186">automotive/v1/ (1)</text>
 </g>

--- a/diagrams/diagram2_directory_tree_light.svg
+++ b/diagrams/diagram2_directory_tree_light.svg
@@ -10,12 +10,16 @@
 <path d="M2 4 H7 L9 6 H18 V18 H2 Z"/>
 </g>
 <text x="70" y="48" font-size="14" font-weight="500" fill="#0f172a" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">international/</text>
-<text x="266" y="48" font-size="12" fill="#64748b">36 policies · 4 frameworks</text>
+<text x="266" y="48" font-size="12" fill="#64748b">43 policies · 8 frameworks</text>
 <g font-size="11" fill="#475569" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
 <text x="70" y="72">eu_ai_act/v1/ (29)</text>
 <text x="220" y="72">nist/v1/ (5)</text>
 <text x="320" y="72">india/v1/ (1)</text>
 <text x="410" y="72">brazil/v1/ (1)</text>
+<text x="70" y="90">icao/v1/ (1)</text>
+<text x="220" y="90">faa/v1/ (2)</text>
+<text x="320" y="90">easa/v1/ (2)</text>
+<text x="410" y="90">standards/v1/ (2)</text>
 </g>
 </g>
 
@@ -26,10 +30,11 @@
 <path d="M2 4 H7 L9 6 H18 V18 H2 Z"/>
 </g>
 <text x="70" y="144" font-size="14" font-weight="500" fill="#0f172a" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">industry_specific/</text>
-<text x="266" y="144" font-size="12" fill="#64748b">17 policies · 4 verticals</text>
+<text x="266" y="144" font-size="12" fill="#64748b">29 policies · 5 verticals</text>
 <g font-size="11" fill="#475569" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
 <text x="70" y="168">education/v1/ (12)</text>
-<text x="220" y="168">healthcare/v1/ (2)</text>
+<text x="220" y="168">aviation/v1/ (12)</text>
+<text x="370" y="168">healthcare/v1/ (2)</text>
 <text x="70" y="186">bfs/v1/ (2)</text>
 <text x="220" y="186">automotive/v1/ (1)</text>
 </g>

--- a/diagrams/hero_banner_dark.svg
+++ b/diagrams/hero_banner_dark.svg
@@ -9,7 +9,7 @@
 </g>
 <text x="128" y="100" font-size="38" font-weight="500" fill="#f0f6fc" letter-spacing="-0.02em">GOPAL</text>
 <text x="128" y="126" font-size="15" font-weight="500" fill="#a5b4fc">The Rego policy library for AI compliance</text>
-<text x="128" y="148" font-size="12" font-weight="400" fill="#8b949e">66 policies · 4 frameworks · Apache 2.0</text>
+<text x="128" y="148" font-size="12" font-weight="400" fill="#8b949e">85 policies · 8 frameworks · Apache 2.0</text>
 
 <g>
 <rect x="562" y="52" width="78" height="24" rx="12" fill="#312e81"/>

--- a/diagrams/hero_banner_light.svg
+++ b/diagrams/hero_banner_light.svg
@@ -9,7 +9,7 @@
 </g>
 <text x="128" y="100" font-size="38" font-weight="500" fill="#0f172a" letter-spacing="-0.02em">GOPAL</text>
 <text x="128" y="126" font-size="15" font-weight="500" fill="#4f46e5">The Rego policy library for AI compliance</text>
-<text x="128" y="148" font-size="12" font-weight="400" fill="#64748b">66 policies · 4 frameworks · Apache 2.0</text>
+<text x="128" y="148" font-size="12" font-weight="400" fill="#64748b">85 policies · 8 frameworks · Apache 2.0</text>
 
 <g>
 <rect x="562" y="52" width="78" height="24" rx="12" fill="#eef2ff"/>

--- a/diagrams/og_card_dark.svg
+++ b/diagrams/og_card_dark.svg
@@ -16,7 +16,7 @@
 <text x="540" y="280" font-size="120" font-weight="500" fill="#f0f6fc" letter-spacing="-0.025em">GOPAL</text>
 
 <text x="600" y="365" font-size="38" font-weight="500" fill="#a5b4fc" text-anchor="middle">The Rego policy library for AI compliance</text>
-<text x="600" y="405" font-size="22" font-weight="400" fill="#8b949e" text-anchor="middle">66 policies · 4 frameworks · 4 industries · Apache 2.0</text>
+<text x="600" y="405" font-size="22" font-weight="400" fill="#8b949e" text-anchor="middle">85 policies · 8 frameworks · 5 industries · Apache 2.0</text>
 
 <g>
 <rect x="296" y="476" width="120" height="36" rx="18" fill="#312e81"/>

--- a/diagrams/og_card_light.svg
+++ b/diagrams/og_card_light.svg
@@ -16,7 +16,7 @@
 <text x="540" y="280" font-size="120" font-weight="500" fill="#0f172a" letter-spacing="-0.025em">GOPAL</text>
 
 <text x="600" y="365" font-size="38" font-weight="500" fill="#4f46e5" text-anchor="middle">The Rego policy library for AI compliance</text>
-<text x="600" y="405" font-size="22" font-weight="400" fill="#64748b" text-anchor="middle">66 policies · 4 frameworks · 4 industries · Apache 2.0</text>
+<text x="600" y="405" font-size="22" font-weight="400" fill="#64748b" text-anchor="middle">85 policies · 8 frameworks · 5 industries · Apache 2.0</text>
 
 <g>
 <rect x="296" y="476" width="120" height="36" rx="18" fill="#eef2ff"/>

--- a/docs/coverage/README.md
+++ b/docs/coverage/README.md
@@ -18,6 +18,8 @@ These frameworks already have real policies in the repo (not scaffolds); nobody 
 - FERPA / COPPA (education) — `industry_specific/education/v1/`
 - Healthcare AI safety — `industry_specific/healthcare/v1/`
 - BFS — fair lending, model risk — `industry_specific/bfs/v1/`
+- ICAO Doc 10019, FAA Part 107/Remote ID, EASA 2019/947/SORA, RTCA DO-365, ISO 21384 — `international/icao/`, `international/faa/`, `international/easa/`, `international/standards/`
+- Aviation industry-vertical policies (airworthiness, autonomous systems, data management, flight operations) — `industry_specific/aviation/v1/`
 
 ## Coming soon
 
@@ -27,7 +29,6 @@ Nothing implemented yet.
 - India DPDP Act (distinct from the Digital India Policy above)
 - California SB-1047 successor
 - MAS / HKMA banking AI guidance
-- Aviation AI/UAS safety (ICAO, FAA, EASA) — drafted on an unmerged feature branch, blocked on test coverage; see the README's Roadmap section
 
 If you want to help expand coverage for a framework, open an issue or send a PR. The matrices are the best place to start — they show contributors exactly which articles, controls, or sections are still open.
 

--- a/industry_specific/README.md
+++ b/industry_specific/README.md
@@ -16,7 +16,10 @@ This directory contains policies specific to particular industry verticals and t
 - **automotive/**: Automotive
   - **v1/**: `vehicle_safety/vehicle_safety.rego`
 
-17 policies total across 4 verticals.
+- **aviation/**: Aviation
+  - **v1/**: 12 policies across `airworthiness/`, `autonomous_systems/`, `data_management/`, and `flight_operations/`. See regulator-specific policies under [`international/icao/`](../international/icao/), [`international/faa/`](../international/faa/), [`international/easa/`](../international/easa/), and [`international/standards/`](../international/standards/).
+
+29 policies total across 5 verticals.
 
 ## Usage
 

--- a/industry_specific/aviation/README.md
+++ b/industry_specific/aviation/README.md
@@ -1,0 +1,16 @@
+# Aviation Policies
+
+This directory contains AI-governance policies for aviation systems, organized by concern area rather than by regulator (see [`international/icao/`](../../international/icao/), [`international/faa/`](../../international/faa/), [`international/easa/`](../../international/easa/), and [`international/standards/`](../../international/standards/) for regulator-specific policies).
+
+## Directory Structure
+
+- **v1/airworthiness/** — type certification, design assurance level, continued-airworthiness maintenance
+- **v1/autonomous_systems/** — AI safety validation, decision-making transparency, human oversight
+- **v1/data_management/** — flight-data sharing agreements, recording/retention, sensor-data privacy
+- **v1/flight_operations/** — BVLOS operations, emergency/contingency procedures, urban air mobility
+
+12 policies total across the four areas.
+
+## Disclaimer
+
+The policies provided in this directory are for informational purposes only and do not constitute legal advice. These policies are based on publicly available information and interpretations of relevant regulations and frameworks. Users are advised to consult with legal professionals for specific guidance related to their AI systems and compliance obligations.

--- a/industry_specific/aviation/v1/airworthiness/README.md
+++ b/industry_specific/aviation/v1/airworthiness/README.md
@@ -1,0 +1,15 @@
+# Airworthiness Policies
+
+Source:
+- **ICAO Annex 8** - Airworthiness of Aircraft
+- **RTCA DO-178C / DO-254** - Software and hardware design assurance for airborne systems
+
+## Policies
+
+- `certification.rego` - type certificate held and airworthiness-directive compliance
+- `design_standards.rego` - software/hardware Design Assurance Level (DAL) matches the system's failure-condition severity
+- `maintenance.rego` - continued-airworthiness maintenance program, current inspections, retained records
+
+## Disclaimer
+
+The policies provided in this directory are for informational purposes only and do not constitute legal advice. These policies are based on publicly available information and interpretations of relevant regulations and frameworks. Users are advised to consult with legal professionals for specific guidance related to their AI systems and compliance obligations.

--- a/industry_specific/aviation/v1/airworthiness/certification.rego
+++ b/industry_specific/aviation/v1/airworthiness/certification.rego
@@ -1,0 +1,41 @@
+# RequiredMetrics:
+#   - aircraft.type_certificate_held
+#   - aircraft.airworthiness_directive_compliant
+#
+# RequiredParams: none
+package industry_specific.aviation.v1.airworthiness.certification
+
+import data.helper_functions.reporting
+import rego.v1
+
+metadata := {
+	"title": "Aviation Type Certification",
+	"description": "Evaluates whether an aircraft holds a valid type certificate and is compliant with all applicable airworthiness directives.",
+	"version": "1.0.0",
+	"category": "Industry-Specific",
+	"references": [
+		"ICAO Annex 8 - Airworthiness of Aircraft",
+	],
+}
+
+default allow := false
+
+allow if {
+	input.aircraft.type_certificate_held == true
+	input.aircraft.airworthiness_directive_compliant == true
+}
+
+policy_metrics := {
+	"type_certificate_held": {
+		"name": "Type Certificate Held",
+		"value": object.get(input.aircraft, "type_certificate_held", false),
+		"control_passed": object.get(input.aircraft, "type_certificate_held", false) == true,
+	},
+	"airworthiness_directive_compliant": {
+		"name": "Airworthiness Directive Compliant",
+		"value": object.get(input.aircraft, "airworthiness_directive_compliant", false),
+		"control_passed": object.get(input.aircraft, "airworthiness_directive_compliant", false) == true,
+	},
+}
+
+report := reporting.compose_report("aviation.airworthiness.certification", allow, policy_metrics)

--- a/industry_specific/aviation/v1/airworthiness/certification_test.rego
+++ b/industry_specific/aviation/v1/airworthiness/certification_test.rego
@@ -1,0 +1,16 @@
+package industry_specific.aviation.v1.airworthiness.certification_test
+
+import data.industry_specific.aviation.v1.airworthiness.certification
+import rego.v1
+
+test_allow_when_certified_and_compliant if {
+	certification.allow with input as {"aircraft": {"type_certificate_held": true, "airworthiness_directive_compliant": true}}
+}
+
+test_deny_without_type_certificate if {
+	not certification.allow with input as {"aircraft": {"type_certificate_held": false, "airworthiness_directive_compliant": true}}
+}
+
+test_deny_without_ad_compliance if {
+	not certification.allow with input as {"aircraft": {"type_certificate_held": true, "airworthiness_directive_compliant": false}}
+}

--- a/industry_specific/aviation/v1/airworthiness/design_standards.rego
+++ b/industry_specific/aviation/v1/airworthiness/design_standards.rego
@@ -1,0 +1,49 @@
+# RequiredMetrics:
+#   - system.failure_condition_severity
+#   - software.design_assurance_level
+#
+# RequiredParams: none
+package industry_specific.aviation.v1.airworthiness.design_standards
+
+import data.helper_functions.reporting
+import rego.v1
+
+metadata := {
+	"title": "Aviation Software/Hardware Design Assurance",
+	"description": "Evaluates whether a system's software Design Assurance Level (DAL) is at least as rigorous as its worst-case failure condition severity requires.",
+	"version": "1.0.0",
+	"category": "Industry-Specific",
+	"references": [
+		"RTCA DO-178C - Software Considerations in Airborne Systems and Equipment Certification",
+		"RTCA DO-254 - Design Assurance Guidance for Airborne Electronic Hardware",
+	],
+}
+
+# Failure condition severity to minimum required DAL, per DO-178C Table (A=Catastrophic ... E=No Effect)
+required_dal := {
+	"catastrophic": "A",
+	"hazardous": "B",
+	"major": "C",
+	"minor": "D",
+	"no_effect": "E",
+}
+
+dal_rank := {"A": 5, "B": 4, "C": 3, "D": 2, "E": 1}
+
+default allow := false
+
+allow if {
+	severity := input.system.failure_condition_severity
+	minimum_dal := required_dal[severity]
+	dal_rank[input.software.design_assurance_level] >= dal_rank[minimum_dal]
+}
+
+policy_metrics := {
+	"design_assurance_level_sufficient": {
+		"name": "Design Assurance Level Meets Failure Condition Severity",
+		"value": object.get(input.software, "design_assurance_level", null),
+		"control_passed": allow,
+	},
+}
+
+report := reporting.compose_report("aviation.airworthiness.design_standards", allow, policy_metrics)

--- a/industry_specific/aviation/v1/airworthiness/design_standards_test.rego
+++ b/industry_specific/aviation/v1/airworthiness/design_standards_test.rego
@@ -1,0 +1,32 @@
+package industry_specific.aviation.v1.airworthiness.design_standards_test
+
+import data.industry_specific.aviation.v1.airworthiness.design_standards
+import rego.v1
+
+test_allow_when_dal_matches_catastrophic_severity if {
+	design_standards.allow with input as {
+		"system": {"failure_condition_severity": "catastrophic"},
+		"software": {"design_assurance_level": "A"},
+	}
+}
+
+test_allow_when_dal_exceeds_requirement if {
+	design_standards.allow with input as {
+		"system": {"failure_condition_severity": "minor"},
+		"software": {"design_assurance_level": "A"},
+	}
+}
+
+test_deny_when_dal_below_requirement if {
+	not design_standards.allow with input as {
+		"system": {"failure_condition_severity": "catastrophic"},
+		"software": {"design_assurance_level": "C"},
+	}
+}
+
+test_allow_for_no_effect_severity_with_level_e if {
+	design_standards.allow with input as {
+		"system": {"failure_condition_severity": "no_effect"},
+		"software": {"design_assurance_level": "E"},
+	}
+}

--- a/industry_specific/aviation/v1/airworthiness/maintenance.rego
+++ b/industry_specific/aviation/v1/airworthiness/maintenance.rego
@@ -1,0 +1,48 @@
+# RequiredMetrics:
+#   - maintenance.program_established
+#   - maintenance.inspection_current
+#   - maintenance.records_retained
+#
+# RequiredParams: none
+package industry_specific.aviation.v1.airworthiness.maintenance
+
+import data.helper_functions.reporting
+import rego.v1
+
+metadata := {
+	"title": "Aviation Continued Airworthiness Maintenance",
+	"description": "Evaluates whether an aircraft has an established maintenance program, current inspections, and retained maintenance records for continued airworthiness.",
+	"version": "1.0.0",
+	"category": "Industry-Specific",
+	"references": [
+		"ICAO Annex 6 - Operation of Aircraft, Part I, Chapter 8 (Aeroplane Maintenance)",
+	],
+}
+
+default allow := false
+
+allow if {
+	input.maintenance.program_established == true
+	input.maintenance.inspection_current == true
+	input.maintenance.records_retained == true
+}
+
+policy_metrics := {
+	"maintenance_program_established": {
+		"name": "Maintenance Program Established",
+		"value": object.get(input.maintenance, "program_established", false),
+		"control_passed": object.get(input.maintenance, "program_established", false) == true,
+	},
+	"inspection_current": {
+		"name": "Inspection Current",
+		"value": object.get(input.maintenance, "inspection_current", false),
+		"control_passed": object.get(input.maintenance, "inspection_current", false) == true,
+	},
+	"records_retained": {
+		"name": "Maintenance Records Retained",
+		"value": object.get(input.maintenance, "records_retained", false),
+		"control_passed": object.get(input.maintenance, "records_retained", false) == true,
+	},
+}
+
+report := reporting.compose_report("aviation.airworthiness.maintenance", allow, policy_metrics)

--- a/industry_specific/aviation/v1/airworthiness/maintenance_test.rego
+++ b/industry_specific/aviation/v1/airworthiness/maintenance_test.rego
@@ -1,0 +1,25 @@
+package industry_specific.aviation.v1.airworthiness.maintenance_test
+
+import data.industry_specific.aviation.v1.airworthiness.maintenance
+import rego.v1
+
+compliant_input := {"maintenance": {"program_established": true, "inspection_current": true, "records_retained": true}}
+
+test_allow_when_fully_compliant if {
+	maintenance.allow with input as compliant_input
+}
+
+test_deny_without_program if {
+	input_data := object.union(compliant_input, {"maintenance": {"program_established": false, "inspection_current": true, "records_retained": true}})
+	not maintenance.allow with input as input_data
+}
+
+test_deny_without_current_inspection if {
+	input_data := object.union(compliant_input, {"maintenance": {"program_established": true, "inspection_current": false, "records_retained": true}})
+	not maintenance.allow with input as input_data
+}
+
+test_deny_without_retained_records if {
+	input_data := object.union(compliant_input, {"maintenance": {"program_established": true, "inspection_current": true, "records_retained": false}})
+	not maintenance.allow with input as input_data
+}

--- a/industry_specific/aviation/v1/autonomous_systems/README.md
+++ b/industry_specific/aviation/v1/autonomous_systems/README.md
@@ -1,0 +1,13 @@
+# Autonomous Systems Policies
+
+Source: **EASA Concept Paper: First usable guidance for Level 1 & 2 machine learning applications**; **ICAO Doc 10019**
+
+## Policies
+
+- `ai_safety.rego` - safety validation, fail-safe mechanisms, performance monitoring
+- `decision_making.rego` - decision logging, explainability, human override capability
+- `human_oversight.rego` - active remote-pilot monitoring, intervention capability, defined handover procedure
+
+## Disclaimer
+
+The policies provided in this directory are for informational purposes only and do not constitute legal advice. These policies are based on publicly available information and interpretations of relevant regulations and frameworks. Users are advised to consult with legal professionals for specific guidance related to their AI systems and compliance obligations.

--- a/industry_specific/aviation/v1/autonomous_systems/ai_safety.rego
+++ b/industry_specific/aviation/v1/autonomous_systems/ai_safety.rego
@@ -1,0 +1,49 @@
+# RequiredMetrics:
+#   - ai_system.safety_validation_completed
+#   - ai_system.fail_safe_mechanism_present
+#   - ai_system.performance_monitoring_enabled
+#
+# RequiredParams: none
+package industry_specific.aviation.v1.autonomous_systems.ai_safety
+
+import data.helper_functions.reporting
+import rego.v1
+
+metadata := {
+	"title": "Aviation AI Safety Requirements",
+	"description": "Evaluates AI safety validation, fail-safe mechanisms, and performance monitoring for autonomous aviation systems.",
+	"version": "1.0.0",
+	"category": "Industry-Specific",
+	"references": [
+		"EASA Concept Paper: First usable guidance for Level 1 & 2 machine learning applications, Issue 2",
+		"ICAO Doc 10019 - Manual on RPAS, Chapter 3",
+	],
+}
+
+default allow := false
+
+allow if {
+	input.ai_system.safety_validation_completed == true
+	input.ai_system.fail_safe_mechanism_present == true
+	input.ai_system.performance_monitoring_enabled == true
+}
+
+policy_metrics := {
+	"safety_validation_completed": {
+		"name": "Safety Validation Completed",
+		"value": object.get(input.ai_system, "safety_validation_completed", false),
+		"control_passed": object.get(input.ai_system, "safety_validation_completed", false) == true,
+	},
+	"fail_safe_mechanism_present": {
+		"name": "Fail-Safe Mechanism Present",
+		"value": object.get(input.ai_system, "fail_safe_mechanism_present", false),
+		"control_passed": object.get(input.ai_system, "fail_safe_mechanism_present", false) == true,
+	},
+	"performance_monitoring_enabled": {
+		"name": "Performance Monitoring Enabled",
+		"value": object.get(input.ai_system, "performance_monitoring_enabled", false),
+		"control_passed": object.get(input.ai_system, "performance_monitoring_enabled", false) == true,
+	},
+}
+
+report := reporting.compose_report("aviation.autonomous_systems.ai_safety", allow, policy_metrics)

--- a/industry_specific/aviation/v1/autonomous_systems/ai_safety_test.rego
+++ b/industry_specific/aviation/v1/autonomous_systems/ai_safety_test.rego
@@ -1,0 +1,29 @@
+package industry_specific.aviation.v1.autonomous_systems.ai_safety_test
+
+import data.industry_specific.aviation.v1.autonomous_systems.ai_safety
+import rego.v1
+
+compliant_input := {"ai_system": {
+	"safety_validation_completed": true,
+	"fail_safe_mechanism_present": true,
+	"performance_monitoring_enabled": true,
+}}
+
+test_allow_when_fully_compliant if {
+	ai_safety.allow with input as compliant_input
+}
+
+test_deny_without_safety_validation if {
+	input_data := object.union(compliant_input, {"ai_system": {"safety_validation_completed": false, "fail_safe_mechanism_present": true, "performance_monitoring_enabled": true}})
+	not ai_safety.allow with input as input_data
+}
+
+test_deny_without_fail_safe_mechanism if {
+	input_data := object.union(compliant_input, {"ai_system": {"safety_validation_completed": true, "fail_safe_mechanism_present": false, "performance_monitoring_enabled": true}})
+	not ai_safety.allow with input as input_data
+}
+
+test_deny_without_performance_monitoring if {
+	input_data := object.union(compliant_input, {"ai_system": {"safety_validation_completed": true, "fail_safe_mechanism_present": true, "performance_monitoring_enabled": false}})
+	not ai_safety.allow with input as input_data
+}

--- a/industry_specific/aviation/v1/autonomous_systems/decision_making.rego
+++ b/industry_specific/aviation/v1/autonomous_systems/decision_making.rego
@@ -1,0 +1,48 @@
+# RequiredMetrics:
+#   - decision_system.decision_logging_enabled
+#   - decision_system.explainable
+#   - decision_system.override_capability
+#
+# RequiredParams: none
+package industry_specific.aviation.v1.autonomous_systems.decision_making
+
+import data.helper_functions.reporting
+import rego.v1
+
+metadata := {
+	"title": "Aviation Autonomous Decision-Making Transparency",
+	"description": "Evaluates whether an autonomous flight decision system logs its decisions, can explain them, and can be overridden.",
+	"version": "1.0.0",
+	"category": "Industry-Specific",
+	"references": [
+		"EASA Concept Paper: First usable guidance for Level 1 & 2 machine learning applications, Issue 2",
+	],
+}
+
+default allow := false
+
+allow if {
+	input.decision_system.decision_logging_enabled == true
+	input.decision_system.explainable == true
+	input.decision_system.override_capability == true
+}
+
+policy_metrics := {
+	"decision_logging_enabled": {
+		"name": "Decision Logging Enabled",
+		"value": object.get(input.decision_system, "decision_logging_enabled", false),
+		"control_passed": object.get(input.decision_system, "decision_logging_enabled", false) == true,
+	},
+	"decision_explainable": {
+		"name": "Decisions Explainable",
+		"value": object.get(input.decision_system, "explainable", false),
+		"control_passed": object.get(input.decision_system, "explainable", false) == true,
+	},
+	"override_capability": {
+		"name": "Human Override Capability",
+		"value": object.get(input.decision_system, "override_capability", false),
+		"control_passed": object.get(input.decision_system, "override_capability", false) == true,
+	},
+}
+
+report := reporting.compose_report("aviation.autonomous_systems.decision_making", allow, policy_metrics)

--- a/industry_specific/aviation/v1/autonomous_systems/decision_making_test.rego
+++ b/industry_specific/aviation/v1/autonomous_systems/decision_making_test.rego
@@ -1,0 +1,29 @@
+package industry_specific.aviation.v1.autonomous_systems.decision_making_test
+
+import data.industry_specific.aviation.v1.autonomous_systems.decision_making
+import rego.v1
+
+compliant_input := {"decision_system": {
+	"decision_logging_enabled": true,
+	"explainable": true,
+	"override_capability": true,
+}}
+
+test_allow_when_fully_compliant if {
+	decision_making.allow with input as compliant_input
+}
+
+test_deny_without_logging if {
+	input_data := object.union(compliant_input, {"decision_system": {"decision_logging_enabled": false, "explainable": true, "override_capability": true}})
+	not decision_making.allow with input as input_data
+}
+
+test_deny_without_explainability if {
+	input_data := object.union(compliant_input, {"decision_system": {"decision_logging_enabled": true, "explainable": false, "override_capability": true}})
+	not decision_making.allow with input as input_data
+}
+
+test_deny_without_override_capability if {
+	input_data := object.union(compliant_input, {"decision_system": {"decision_logging_enabled": true, "explainable": true, "override_capability": false}})
+	not decision_making.allow with input as input_data
+}

--- a/industry_specific/aviation/v1/autonomous_systems/human_oversight.rego
+++ b/industry_specific/aviation/v1/autonomous_systems/human_oversight.rego
@@ -1,0 +1,48 @@
+# RequiredMetrics:
+#   - oversight.remote_pilot_monitoring
+#   - oversight.intervention_capability
+#   - oversight.handover_procedure_defined
+#
+# RequiredParams: none
+package industry_specific.aviation.v1.autonomous_systems.human_oversight
+
+import data.helper_functions.reporting
+import rego.v1
+
+metadata := {
+	"title": "Aviation Human Oversight of Autonomous Operation",
+	"description": "Evaluates whether an autonomous aviation system maintains active remote-pilot monitoring, a real-time intervention capability, and a defined handover procedure.",
+	"version": "1.0.0",
+	"category": "Industry-Specific",
+	"references": [
+		"ICAO Doc 10019 - Manual on RPAS, Chapter 3 (C2 Link and Human Factors)",
+	],
+}
+
+default allow := false
+
+allow if {
+	input.oversight.remote_pilot_monitoring == true
+	input.oversight.intervention_capability == true
+	input.oversight.handover_procedure_defined == true
+}
+
+policy_metrics := {
+	"remote_pilot_monitoring": {
+		"name": "Remote Pilot Monitoring Active",
+		"value": object.get(input.oversight, "remote_pilot_monitoring", false),
+		"control_passed": object.get(input.oversight, "remote_pilot_monitoring", false) == true,
+	},
+	"intervention_capability": {
+		"name": "Intervention Capability Present",
+		"value": object.get(input.oversight, "intervention_capability", false),
+		"control_passed": object.get(input.oversight, "intervention_capability", false) == true,
+	},
+	"handover_procedure_defined": {
+		"name": "Handover Procedure Defined",
+		"value": object.get(input.oversight, "handover_procedure_defined", false),
+		"control_passed": object.get(input.oversight, "handover_procedure_defined", false) == true,
+	},
+}
+
+report := reporting.compose_report("aviation.autonomous_systems.human_oversight", allow, policy_metrics)

--- a/industry_specific/aviation/v1/autonomous_systems/human_oversight_test.rego
+++ b/industry_specific/aviation/v1/autonomous_systems/human_oversight_test.rego
@@ -1,0 +1,29 @@
+package industry_specific.aviation.v1.autonomous_systems.human_oversight_test
+
+import data.industry_specific.aviation.v1.autonomous_systems.human_oversight
+import rego.v1
+
+compliant_input := {"oversight": {
+	"remote_pilot_monitoring": true,
+	"intervention_capability": true,
+	"handover_procedure_defined": true,
+}}
+
+test_allow_when_fully_compliant if {
+	human_oversight.allow with input as compliant_input
+}
+
+test_deny_without_monitoring if {
+	input_data := object.union(compliant_input, {"oversight": {"remote_pilot_monitoring": false, "intervention_capability": true, "handover_procedure_defined": true}})
+	not human_oversight.allow with input as input_data
+}
+
+test_deny_without_intervention_capability if {
+	input_data := object.union(compliant_input, {"oversight": {"remote_pilot_monitoring": true, "intervention_capability": false, "handover_procedure_defined": true}})
+	not human_oversight.allow with input as input_data
+}
+
+test_deny_without_handover_procedure if {
+	input_data := object.union(compliant_input, {"oversight": {"remote_pilot_monitoring": true, "intervention_capability": true, "handover_procedure_defined": false}})
+	not human_oversight.allow with input as input_data
+}

--- a/industry_specific/aviation/v1/data_management/README.md
+++ b/industry_specific/aviation/v1/data_management/README.md
@@ -1,0 +1,13 @@
+# Data Management Policies
+
+Source: **ICAO Annex 6** (flight recorders); **ICAO Doc 10019** (C2 link data); **EASA** rules on UAS operations and privacy
+
+## Policies
+
+- `data_sharing.rego` - data-sharing agreement in place and recipient authorized
+- `flight_data.rego` - flight-data recording enabled and retained for a minimum period
+- `privacy_protection.rego` - data minimization applied and a lawful basis (consent or otherwise) established for sensor data collection
+
+## Disclaimer
+
+The policies provided in this directory are for informational purposes only and do not constitute legal advice. These policies are based on publicly available information and interpretations of relevant regulations and frameworks. Users are advised to consult with legal professionals for specific guidance related to their AI systems and compliance obligations.

--- a/industry_specific/aviation/v1/data_management/data_sharing.rego
+++ b/industry_specific/aviation/v1/data_management/data_sharing.rego
@@ -1,0 +1,41 @@
+# RequiredMetrics:
+#   - data_sharing.agreement_in_place
+#   - data_sharing.recipient_authorized
+#
+# RequiredParams: none
+package industry_specific.aviation.v1.data_management.data_sharing
+
+import data.helper_functions.reporting
+import rego.v1
+
+metadata := {
+	"title": "Aviation Flight Data Sharing",
+	"description": "Evaluates whether flight data shared with third parties (ATC, regulators, fleet operators) has a data-sharing agreement in place and the recipient is authorized.",
+	"version": "1.0.0",
+	"category": "Industry-Specific",
+	"references": [
+		"ICAO Doc 10019 - Manual on RPAS, Chapter 3 (C2 Link data)",
+	],
+}
+
+default allow := false
+
+allow if {
+	input.data_sharing.agreement_in_place == true
+	input.data_sharing.recipient_authorized == true
+}
+
+policy_metrics := {
+	"agreement_in_place": {
+		"name": "Data Sharing Agreement in Place",
+		"value": object.get(input.data_sharing, "agreement_in_place", false),
+		"control_passed": object.get(input.data_sharing, "agreement_in_place", false) == true,
+	},
+	"recipient_authorized": {
+		"name": "Recipient Authorized",
+		"value": object.get(input.data_sharing, "recipient_authorized", false),
+		"control_passed": object.get(input.data_sharing, "recipient_authorized", false) == true,
+	},
+}
+
+report := reporting.compose_report("aviation.data_management.data_sharing", allow, policy_metrics)

--- a/industry_specific/aviation/v1/data_management/data_sharing_test.rego
+++ b/industry_specific/aviation/v1/data_management/data_sharing_test.rego
@@ -1,0 +1,16 @@
+package industry_specific.aviation.v1.data_management.data_sharing_test
+
+import data.industry_specific.aviation.v1.data_management.data_sharing
+import rego.v1
+
+test_allow_when_agreement_and_authorization_present if {
+	data_sharing.allow with input as {"data_sharing": {"agreement_in_place": true, "recipient_authorized": true}}
+}
+
+test_deny_without_agreement if {
+	not data_sharing.allow with input as {"data_sharing": {"agreement_in_place": false, "recipient_authorized": true}}
+}
+
+test_deny_without_authorized_recipient if {
+	not data_sharing.allow with input as {"data_sharing": {"agreement_in_place": true, "recipient_authorized": false}}
+}

--- a/industry_specific/aviation/v1/data_management/flight_data.rego
+++ b/industry_specific/aviation/v1/data_management/flight_data.rego
@@ -1,0 +1,42 @@
+# RequiredMetrics:
+#   - flight_data.recording_enabled
+#   - flight_data.retention_days
+#
+# RequiredParams:
+#   - min_retention_days (default 90)
+package industry_specific.aviation.v1.data_management.flight_data
+
+import data.helper_functions.reporting
+import rego.v1
+
+metadata := {
+	"title": "Aviation Flight Data Recording and Retention",
+	"description": "Evaluates whether flight data recording is enabled and retained for at least the minimum required period.",
+	"version": "1.0.0",
+	"category": "Industry-Specific",
+	"references": [
+		"ICAO Annex 6 - Operation of Aircraft, Chapter 4 (Flight Recorders)",
+	],
+}
+
+default allow := false
+
+allow if {
+	input.flight_data.recording_enabled == true
+	input.flight_data.retention_days >= object.get(input.params, "min_retention_days", 90)
+}
+
+policy_metrics := {
+	"recording_enabled": {
+		"name": "Flight Data Recording Enabled",
+		"value": object.get(input.flight_data, "recording_enabled", false),
+		"control_passed": object.get(input.flight_data, "recording_enabled", false) == true,
+	},
+	"retention_sufficient": {
+		"name": "Retention Period Sufficient",
+		"value": object.get(input.flight_data, "retention_days", 0),
+		"control_passed": object.get(input.flight_data, "retention_days", 0) >= object.get(input.params, "min_retention_days", 90),
+	},
+}
+
+report := reporting.compose_report("aviation.data_management.flight_data", allow, policy_metrics)

--- a/industry_specific/aviation/v1/data_management/flight_data_test.rego
+++ b/industry_specific/aviation/v1/data_management/flight_data_test.rego
@@ -1,0 +1,20 @@
+package industry_specific.aviation.v1.data_management.flight_data_test
+
+import data.industry_specific.aviation.v1.data_management.flight_data
+import rego.v1
+
+test_allow_when_recording_and_retention_sufficient if {
+	flight_data.allow with input as {"flight_data": {"recording_enabled": true, "retention_days": 120}, "params": {}}
+}
+
+test_deny_without_recording if {
+	not flight_data.allow with input as {"flight_data": {"recording_enabled": false, "retention_days": 120}, "params": {}}
+}
+
+test_deny_with_insufficient_retention if {
+	not flight_data.allow with input as {"flight_data": {"recording_enabled": true, "retention_days": 30}, "params": {}}
+}
+
+test_allow_with_custom_retention_param if {
+	flight_data.allow with input as {"flight_data": {"recording_enabled": true, "retention_days": 30}, "params": {"min_retention_days": 30}}
+}

--- a/industry_specific/aviation/v1/data_management/privacy_protection.rego
+++ b/industry_specific/aviation/v1/data_management/privacy_protection.rego
@@ -1,0 +1,41 @@
+# RequiredMetrics:
+#   - privacy.data_minimization_applied
+#   - privacy.consent_or_legal_basis
+#
+# RequiredParams: none
+package industry_specific.aviation.v1.data_management.privacy_protection
+
+import data.helper_functions.reporting
+import rego.v1
+
+metadata := {
+	"title": "Aviation Sensor Data Privacy Protection",
+	"description": "Evaluates whether camera and sensor data collected during flight (which may capture third parties or private property) applies data minimization and has a lawful basis for collection.",
+	"version": "1.0.0",
+	"category": "Industry-Specific",
+	"references": [
+		"EASA Easy Access Rules for Unmanned Aircraft Systems, Article 5 (Rules for UAS operations conducted... with regard to privacy)",
+	],
+}
+
+default allow := false
+
+allow if {
+	input.privacy.data_minimization_applied == true
+	input.privacy.consent_or_legal_basis == true
+}
+
+policy_metrics := {
+	"data_minimization_applied": {
+		"name": "Data Minimization Applied",
+		"value": object.get(input.privacy, "data_minimization_applied", false),
+		"control_passed": object.get(input.privacy, "data_minimization_applied", false) == true,
+	},
+	"consent_or_legal_basis": {
+		"name": "Consent or Legal Basis Established",
+		"value": object.get(input.privacy, "consent_or_legal_basis", false),
+		"control_passed": object.get(input.privacy, "consent_or_legal_basis", false) == true,
+	},
+}
+
+report := reporting.compose_report("aviation.data_management.privacy_protection", allow, policy_metrics)

--- a/industry_specific/aviation/v1/data_management/privacy_protection_test.rego
+++ b/industry_specific/aviation/v1/data_management/privacy_protection_test.rego
@@ -1,0 +1,16 @@
+package industry_specific.aviation.v1.data_management.privacy_protection_test
+
+import data.industry_specific.aviation.v1.data_management.privacy_protection
+import rego.v1
+
+test_allow_when_minimized_and_lawful if {
+	privacy_protection.allow with input as {"privacy": {"data_minimization_applied": true, "consent_or_legal_basis": true}}
+}
+
+test_deny_without_data_minimization if {
+	not privacy_protection.allow with input as {"privacy": {"data_minimization_applied": false, "consent_or_legal_basis": true}}
+}
+
+test_deny_without_legal_basis if {
+	not privacy_protection.allow with input as {"privacy": {"data_minimization_applied": true, "consent_or_legal_basis": false}}
+}

--- a/industry_specific/aviation/v1/flight_operations/README.md
+++ b/industry_specific/aviation/v1/flight_operations/README.md
@@ -1,0 +1,13 @@
+# Flight Operations Policies
+
+Source: **14 CFR Part 107** (BVLOS waivers); **EASA SORA**; **FAA UAM Concept of Operations v2.0**; **EASA Special Condition VTOL (SC-VTOL-01)**
+
+## Policies
+
+- `bvlos_operations.rego` - detect-and-avoid equipage, authorization/waiver held, ground-risk mitigations in place
+- `emergency_procedures.rego` - lost-link procedure defined, contingency landing sites identified, crew trained
+- `urban_air_mobility.rego` - vertiport certification, community noise limit, authorized flight corridor
+
+## Disclaimer
+
+The policies provided in this directory are for informational purposes only and do not constitute legal advice. These policies are based on publicly available information and interpretations of relevant regulations and frameworks. Users are advised to consult with legal professionals for specific guidance related to their AI systems and compliance obligations.

--- a/industry_specific/aviation/v1/flight_operations/bvlos_operations.rego
+++ b/industry_specific/aviation/v1/flight_operations/bvlos_operations.rego
@@ -1,0 +1,49 @@
+# RequiredMetrics:
+#   - operation.daa_system_equipped
+#   - operation.authorization_held
+#   - operation.ground_risk_mitigations_in_place
+#
+# RequiredParams: none
+package industry_specific.aviation.v1.flight_operations.bvlos_operations
+
+import data.helper_functions.reporting
+import rego.v1
+
+metadata := {
+	"title": "Beyond Visual Line of Sight Operations",
+	"description": "Evaluates whether a BVLOS operation has detect-and-avoid capability, a governing authorization or waiver, and ground-risk mitigations in place.",
+	"version": "1.0.0",
+	"category": "Industry-Specific",
+	"references": [
+		"14 CFR Part 107 Subpart D - Waivers (Sec. 107.31 BVLOS)",
+		"EASA SORA methodology, ground risk mitigations",
+	],
+}
+
+default allow := false
+
+allow if {
+	input.operation.daa_system_equipped == true
+	input.operation.authorization_held == true
+	input.operation.ground_risk_mitigations_in_place == true
+}
+
+policy_metrics := {
+	"daa_system_equipped": {
+		"name": "Detect and Avoid System Equipped",
+		"value": object.get(input.operation, "daa_system_equipped", false),
+		"control_passed": object.get(input.operation, "daa_system_equipped", false) == true,
+	},
+	"authorization_held": {
+		"name": "Authorization or Waiver Held",
+		"value": object.get(input.operation, "authorization_held", false),
+		"control_passed": object.get(input.operation, "authorization_held", false) == true,
+	},
+	"ground_risk_mitigations_in_place": {
+		"name": "Ground Risk Mitigations in Place",
+		"value": object.get(input.operation, "ground_risk_mitigations_in_place", false),
+		"control_passed": object.get(input.operation, "ground_risk_mitigations_in_place", false) == true,
+	},
+}
+
+report := reporting.compose_report("aviation.flight_operations.bvlos_operations", allow, policy_metrics)

--- a/industry_specific/aviation/v1/flight_operations/bvlos_operations_test.rego
+++ b/industry_specific/aviation/v1/flight_operations/bvlos_operations_test.rego
@@ -1,0 +1,29 @@
+package industry_specific.aviation.v1.flight_operations.bvlos_operations_test
+
+import data.industry_specific.aviation.v1.flight_operations.bvlos_operations
+import rego.v1
+
+compliant_input := {"operation": {
+	"daa_system_equipped": true,
+	"authorization_held": true,
+	"ground_risk_mitigations_in_place": true,
+}}
+
+test_allow_when_fully_compliant if {
+	bvlos_operations.allow with input as compliant_input
+}
+
+test_deny_without_daa_system if {
+	input_data := object.union(compliant_input, {"operation": {"daa_system_equipped": false, "authorization_held": true, "ground_risk_mitigations_in_place": true}})
+	not bvlos_operations.allow with input as input_data
+}
+
+test_deny_without_authorization if {
+	input_data := object.union(compliant_input, {"operation": {"daa_system_equipped": true, "authorization_held": false, "ground_risk_mitigations_in_place": true}})
+	not bvlos_operations.allow with input as input_data
+}
+
+test_deny_without_ground_risk_mitigations if {
+	input_data := object.union(compliant_input, {"operation": {"daa_system_equipped": true, "authorization_held": true, "ground_risk_mitigations_in_place": false}})
+	not bvlos_operations.allow with input as input_data
+}

--- a/industry_specific/aviation/v1/flight_operations/emergency_procedures.rego
+++ b/industry_specific/aviation/v1/flight_operations/emergency_procedures.rego
@@ -1,0 +1,48 @@
+# RequiredMetrics:
+#   - emergency_procedures.lost_link_procedure_defined
+#   - emergency_procedures.contingency_landing_sites_identified
+#   - emergency_procedures.crew_trained
+#
+# RequiredParams: none
+package industry_specific.aviation.v1.flight_operations.emergency_procedures
+
+import data.helper_functions.reporting
+import rego.v1
+
+metadata := {
+	"title": "Aviation Emergency and Contingency Procedures",
+	"description": "Evaluates whether an operation has a defined lost-link procedure, identified contingency landing sites, and trained crew for emergency response.",
+	"version": "1.0.0",
+	"category": "Industry-Specific",
+	"references": [
+		"ICAO Doc 10019 - Manual on RPAS, Chapter 3 (C2 Link failure contingencies)",
+	],
+}
+
+default allow := false
+
+allow if {
+	input.emergency_procedures.lost_link_procedure_defined == true
+	input.emergency_procedures.contingency_landing_sites_identified == true
+	input.emergency_procedures.crew_trained == true
+}
+
+policy_metrics := {
+	"lost_link_procedure_defined": {
+		"name": "Lost Link Procedure Defined",
+		"value": object.get(input.emergency_procedures, "lost_link_procedure_defined", false),
+		"control_passed": object.get(input.emergency_procedures, "lost_link_procedure_defined", false) == true,
+	},
+	"contingency_landing_sites_identified": {
+		"name": "Contingency Landing Sites Identified",
+		"value": object.get(input.emergency_procedures, "contingency_landing_sites_identified", false),
+		"control_passed": object.get(input.emergency_procedures, "contingency_landing_sites_identified", false) == true,
+	},
+	"crew_trained": {
+		"name": "Crew Trained on Emergency Procedures",
+		"value": object.get(input.emergency_procedures, "crew_trained", false),
+		"control_passed": object.get(input.emergency_procedures, "crew_trained", false) == true,
+	},
+}
+
+report := reporting.compose_report("aviation.flight_operations.emergency_procedures", allow, policy_metrics)

--- a/industry_specific/aviation/v1/flight_operations/emergency_procedures_test.rego
+++ b/industry_specific/aviation/v1/flight_operations/emergency_procedures_test.rego
@@ -1,0 +1,29 @@
+package industry_specific.aviation.v1.flight_operations.emergency_procedures_test
+
+import data.industry_specific.aviation.v1.flight_operations.emergency_procedures
+import rego.v1
+
+compliant_input := {"emergency_procedures": {
+	"lost_link_procedure_defined": true,
+	"contingency_landing_sites_identified": true,
+	"crew_trained": true,
+}}
+
+test_allow_when_fully_compliant if {
+	emergency_procedures.allow with input as compliant_input
+}
+
+test_deny_without_lost_link_procedure if {
+	input_data := object.union(compliant_input, {"emergency_procedures": {"lost_link_procedure_defined": false, "contingency_landing_sites_identified": true, "crew_trained": true}})
+	not emergency_procedures.allow with input as input_data
+}
+
+test_deny_without_contingency_sites if {
+	input_data := object.union(compliant_input, {"emergency_procedures": {"lost_link_procedure_defined": true, "contingency_landing_sites_identified": false, "crew_trained": true}})
+	not emergency_procedures.allow with input as input_data
+}
+
+test_deny_without_crew_training if {
+	input_data := object.union(compliant_input, {"emergency_procedures": {"lost_link_procedure_defined": true, "contingency_landing_sites_identified": true, "crew_trained": false}})
+	not emergency_procedures.allow with input as input_data
+}

--- a/industry_specific/aviation/v1/flight_operations/urban_air_mobility.rego
+++ b/industry_specific/aviation/v1/flight_operations/urban_air_mobility.rego
@@ -1,0 +1,50 @@
+# RequiredMetrics:
+#   - uam.vertiport_certified
+#   - uam.noise_compliant
+#   - uam.corridor_authorized
+#
+# RequiredParams:
+#   - max_noise_db (default 65)
+package industry_specific.aviation.v1.flight_operations.urban_air_mobility
+
+import data.helper_functions.reporting
+import rego.v1
+
+metadata := {
+	"title": "Urban Air Mobility Operations",
+	"description": "Evaluates Advanced/Urban Air Mobility operations against vertiport certification, community noise limits, and authorized-corridor requirements.",
+	"version": "1.0.0",
+	"category": "Industry-Specific",
+	"references": [
+		"FAA Urban Air Mobility (UAM) Concept of Operations v2.0",
+		"EASA Special Condition VTOL (SC-VTOL-01)",
+	],
+}
+
+default allow := false
+
+allow if {
+	input.uam.vertiport_certified == true
+	input.uam.noise_db <= object.get(input.params, "max_noise_db", 65)
+	input.uam.corridor_authorized == true
+}
+
+policy_metrics := {
+	"vertiport_certified": {
+		"name": "Vertiport Certified",
+		"value": object.get(input.uam, "vertiport_certified", false),
+		"control_passed": object.get(input.uam, "vertiport_certified", false) == true,
+	},
+	"noise_within_limit": {
+		"name": "Noise Within Community Limit",
+		"value": object.get(input.uam, "noise_db", null),
+		"control_passed": object.get(input.uam, "noise_db", 999) <= object.get(input.params, "max_noise_db", 65),
+	},
+	"corridor_authorized": {
+		"name": "Flight Corridor Authorized",
+		"value": object.get(input.uam, "corridor_authorized", false),
+		"control_passed": object.get(input.uam, "corridor_authorized", false) == true,
+	},
+}
+
+report := reporting.compose_report("aviation.flight_operations.urban_air_mobility", allow, policy_metrics)

--- a/industry_specific/aviation/v1/flight_operations/urban_air_mobility_test.rego
+++ b/industry_specific/aviation/v1/flight_operations/urban_air_mobility_test.rego
@@ -1,0 +1,33 @@
+package industry_specific.aviation.v1.flight_operations.urban_air_mobility_test
+
+import data.industry_specific.aviation.v1.flight_operations.urban_air_mobility
+import rego.v1
+
+compliant_input := {
+	"uam": {"vertiport_certified": true, "noise_db": 60, "corridor_authorized": true},
+	"params": {},
+}
+
+test_allow_when_fully_compliant if {
+	urban_air_mobility.allow with input as compliant_input
+}
+
+test_deny_without_vertiport_certification if {
+	input_data := object.union(compliant_input, {"uam": {"vertiport_certified": false, "noise_db": 60, "corridor_authorized": true}})
+	not urban_air_mobility.allow with input as input_data
+}
+
+test_deny_when_noise_exceeds_limit if {
+	input_data := object.union(compliant_input, {"uam": {"vertiport_certified": true, "noise_db": 80, "corridor_authorized": true}})
+	not urban_air_mobility.allow with input as input_data
+}
+
+test_deny_without_corridor_authorization if {
+	input_data := object.union(compliant_input, {"uam": {"vertiport_certified": true, "noise_db": 60, "corridor_authorized": false}})
+	not urban_air_mobility.allow with input as input_data
+}
+
+test_allow_with_custom_noise_param if {
+	input_data := object.union(compliant_input, {"uam": {"vertiport_certified": true, "noise_db": 70, "corridor_authorized": true}, "params": {"max_noise_db": 75}})
+	urban_air_mobility.allow with input as input_data
+}

--- a/international/README.md
+++ b/international/README.md
@@ -16,7 +16,19 @@ This directory contains policies for named regulatory frameworks that cross a si
 - **brazil/**: Brazil
   - **v1/**: `ai_governance/ai_governance.rego` (AI Governance Bill)
 
-36 policies total across 4 frameworks.
+- **icao/**: ICAO Doc 10019 (Manual on RPAS)
+  - **v1/**: `doc_10019.rego`
+
+- **faa/**: US Federal Aviation Administration
+  - **v1/**: 2 policies — `part_107.rego` (small UAS operating rules), `remote_id.rego` (Remote ID)
+
+- **easa/**: EU Aviation Safety Agency
+  - **v1/**: 2 policies — `regulation_2019_947.rego` (UAS operation categories), `sora.rego` (Specific Operations Risk Assessment)
+
+- **standards/**: Aviation industry standards (not tied to one regulator)
+  - **v1/**: 2 policies — `rtca_do_365.rego` (Detect and Avoid MOPS), `iso_21384.rego` (UAS general requirements)
+
+43 policies total across 8 frameworks.
 
 ## Usage
 

--- a/international/easa/README.md
+++ b/international/easa/README.md
@@ -1,0 +1,13 @@
+# EASA (European Union Aviation Safety Agency) Policies
+
+This directory contains OPA Rego policies for compliance with EU regulations for uncrewed aircraft systems.
+
+## Directory Structure
+
+- **v1/**:
+  - `regulation_2019_947.rego` - Commission Implementing Regulation (EU) 2019/947: Open, Specific, and Certified category requirements
+  - `sora.rego` - Specific Operations Risk Assessment (SORA): ground risk class, air risk class, SAIL determination, and mitigations
+
+## Disclaimer
+
+The policies provided in this directory are for informational purposes only and do not constitute legal advice. These policies are based on publicly available information and interpretations of relevant regulations and frameworks. Users are advised to consult with legal professionals for specific guidance related to their AI systems and compliance obligations.

--- a/international/easa/v1/regulation_2019_947.rego
+++ b/international/easa/v1/regulation_2019_947.rego
@@ -1,0 +1,56 @@
+# RequiredMetrics:
+#   - operation.category
+#   - operator.registered
+#   - aircraft.class_marking
+#   - authorization.granted
+#
+# RequiredParams: none
+package international.easa.v1.regulation_2019_947
+
+import data.helper_functions.reporting
+import rego.v1
+
+metadata := {
+	"title": "EASA Regulation 2019/947 - Rules for UAS Operation",
+	"description": "Evaluates UAS operations against the Open, Specific, and Certified category requirements of Commission Implementing Regulation (EU) 2019/947.",
+	"version": "1.0.0",
+	"category": "International",
+	"references": [
+		"Commission Implementing Regulation (EU) 2019/947, Annex Part A (Open category), Part B (Specific category)",
+	],
+}
+
+default allow := false
+
+allow if {
+	input.operation.category == "open"
+	input.operator.registered == true
+	input.aircraft.class_marking in {"C0", "C1", "C2", "C3", "C4"}
+}
+
+allow if {
+	input.operation.category == "specific"
+	input.operator.registered == true
+	input.authorization.granted == true
+}
+
+allow if {
+	input.operation.category == "certified"
+	input.operator.registered == true
+	input.aircraft.type_certificate_held == true
+}
+
+policy_metrics := {
+	"operator_registered": {
+		"name": "Operator Registered",
+		"value": object.get(input.operator, "registered", false),
+		"control_passed": object.get(input.operator, "registered", false) == true,
+	},
+	"category_requirements_met": {
+		"name": "Category-Specific Requirements Met",
+		"value": allow,
+		"control_passed": allow,
+	},
+}
+
+report := reporting.compose_report("easa.regulation_2019_947", allow, policy_metrics)

--- a/international/easa/v1/regulation_2019_947_test.rego
+++ b/international/easa/v1/regulation_2019_947_test.rego
@@ -1,0 +1,58 @@
+package international.easa.v1.regulation_2019_947_test
+
+import data.international.easa.v1.regulation_2019_947
+import rego.v1
+
+test_allow_open_category_with_class_marking if {
+	regulation_2019_947.allow with input as {
+		"operation": {"category": "open"},
+		"operator": {"registered": true},
+		"aircraft": {"class_marking": "C1"},
+		"authorization": {"granted": false},
+	}
+}
+
+test_deny_open_category_without_class_marking if {
+	not regulation_2019_947.allow with input as {
+		"operation": {"category": "open"},
+		"operator": {"registered": true},
+		"aircraft": {"class_marking": "unmarked"},
+		"authorization": {"granted": false},
+	}
+}
+
+test_allow_specific_category_with_authorization if {
+	regulation_2019_947.allow with input as {
+		"operation": {"category": "specific"},
+		"operator": {"registered": true},
+		"aircraft": {"class_marking": "unmarked"},
+		"authorization": {"granted": true},
+	}
+}
+
+test_deny_specific_category_without_authorization if {
+	not regulation_2019_947.allow with input as {
+		"operation": {"category": "specific"},
+		"operator": {"registered": true},
+		"aircraft": {"class_marking": "unmarked"},
+		"authorization": {"granted": false},
+	}
+}
+
+test_allow_certified_category_with_type_certificate if {
+	regulation_2019_947.allow with input as {
+		"operation": {"category": "certified"},
+		"operator": {"registered": true},
+		"aircraft": {"type_certificate_held": true},
+		"authorization": {"granted": false},
+	}
+}
+
+test_deny_when_operator_not_registered if {
+	not regulation_2019_947.allow with input as {
+		"operation": {"category": "open"},
+		"operator": {"registered": false},
+		"aircraft": {"class_marking": "C1"},
+		"authorization": {"granted": false},
+	}
+}

--- a/international/easa/v1/sora.rego
+++ b/international/easa/v1/sora.rego
@@ -1,0 +1,56 @@
+# RequiredMetrics:
+#   - assessment.ground_risk_class
+#   - assessment.air_risk_class
+#   - assessment.sail_determined
+#   - mitigations.adequate
+#
+# RequiredParams: none
+package international.easa.v1.sora
+
+import data.helper_functions.reporting
+import rego.v1
+
+metadata := {
+	"title": "EASA SORA - Specific Operations Risk Assessment",
+	"description": "Evaluates whether a Specific-category UAS operation has completed a SORA risk assessment (ground risk class, air risk class, resulting SAIL) with adequate mitigations in place.",
+	"version": "1.0.0",
+	"category": "International",
+	"references": [
+		"EASA Easy Access Rules for Unmanned Aircraft Systems, SORA methodology (Annex to AMC1 Article 11 of Regulation (EU) 2019/947)",
+	],
+}
+
+default allow := false
+
+allow if {
+	input.assessment.ground_risk_class >= 1
+	input.assessment.ground_risk_class <= 10
+	input.assessment.air_risk_class in {"a", "b", "c", "d"}
+	input.assessment.sail_determined == true
+	input.mitigations.adequate == true
+}
+
+policy_metrics := {
+	"ground_risk_class_assessed": {
+		"name": "Ground Risk Class Assessed",
+		"value": object.get(input.assessment, "ground_risk_class", null),
+		"control_passed": object.get(input.assessment, "ground_risk_class", 0) >= 1,
+	},
+	"air_risk_class_assessed": {
+		"name": "Air Risk Class Assessed",
+		"value": object.get(input.assessment, "air_risk_class", null),
+		"control_passed": object.get(input.assessment, "air_risk_class", "") in {"a", "b", "c", "d"},
+	},
+	"sail_determined": {
+		"name": "SAIL Determined",
+		"value": object.get(input.assessment, "sail_determined", false),
+		"control_passed": object.get(input.assessment, "sail_determined", false) == true,
+	},
+	"mitigations_adequate": {
+		"name": "Mitigations Adequate for SAIL",
+		"value": object.get(input.mitigations, "adequate", false),
+		"control_passed": object.get(input.mitigations, "adequate", false) == true,
+	},
+}
+
+report := reporting.compose_report("easa.sora", allow, policy_metrics)

--- a/international/easa/v1/sora_test.rego
+++ b/international/easa/v1/sora_test.rego
@@ -1,0 +1,39 @@
+package international.easa.v1.sora_test
+
+import data.international.easa.v1.sora
+import rego.v1
+
+test_allow_when_fully_assessed_and_mitigated if {
+	sora.allow with input as {
+		"assessment": {"ground_risk_class": 4, "air_risk_class": "b", "sail_determined": true},
+		"mitigations": {"adequate": true},
+	}
+}
+
+test_deny_without_ground_risk_class if {
+	not sora.allow with input as {
+		"assessment": {"ground_risk_class": 0, "air_risk_class": "b", "sail_determined": true},
+		"mitigations": {"adequate": true},
+	}
+}
+
+test_deny_with_invalid_air_risk_class if {
+	not sora.allow with input as {
+		"assessment": {"ground_risk_class": 4, "air_risk_class": "z", "sail_determined": true},
+		"mitigations": {"adequate": true},
+	}
+}
+
+test_deny_without_sail_determined if {
+	not sora.allow with input as {
+		"assessment": {"ground_risk_class": 4, "air_risk_class": "b", "sail_determined": false},
+		"mitigations": {"adequate": true},
+	}
+}
+
+test_deny_without_adequate_mitigations if {
+	not sora.allow with input as {
+		"assessment": {"ground_risk_class": 4, "air_risk_class": "b", "sail_determined": true},
+		"mitigations": {"adequate": false},
+	}
+}

--- a/international/faa/README.md
+++ b/international/faa/README.md
@@ -1,0 +1,13 @@
+# FAA (Federal Aviation Administration) Policies
+
+This directory contains OPA Rego policies for compliance with United States FAA regulations for uncrewed aircraft systems.
+
+## Directory Structure
+
+- **v1/**:
+  - `part_107.rego` - 14 CFR Part 107 small UAS operating rules: remote pilot certification, registration, altitude limit, visual line of sight, daylight/lighting
+  - `remote_id.rego` - 14 CFR Part 89 Remote ID: Standard Remote ID, broadcast module, or FAA-Recognized Identification Area (FRIA)
+
+## Disclaimer
+
+The policies provided in this directory are for informational purposes only and do not constitute legal advice. These policies are based on publicly available information and interpretations of relevant regulations and frameworks. Users are advised to consult with legal professionals for specific guidance related to their AI systems and compliance obligations.

--- a/international/faa/v1/part_107.rego
+++ b/international/faa/v1/part_107.rego
@@ -1,0 +1,77 @@
+# RequiredMetrics:
+#   - remote_pilot.certificate_held
+#   - aircraft.registered
+#   - operation.altitude_ft
+#   - operation.visual_line_of_sight
+#   - operation.daylight_or_lit
+#
+# RequiredParams:
+#   - max_altitude_ft (default 400)
+package international.faa.v1.part_107
+
+import data.helper_functions.reporting
+import rego.v1
+
+metadata := {
+	"title": "FAA Part 107 - Small Unmanned Aircraft Systems",
+	"description": "Evaluates small UAS operations against 14 CFR Part 107 operating rules: pilot certification, registration, altitude limit, visual line of sight, and daylight/lighting requirements.",
+	"version": "1.0.0",
+	"category": "International",
+	"references": [
+		"14 CFR Part 107 Subpart B - Operating Rules (Sec. 107.31, 107.51)",
+		"14 CFR Part 107 Subpart C - Remote Pilot Certification (Sec. 107.12)",
+	],
+}
+
+default allow := false
+
+allow if {
+	input.remote_pilot.certificate_held == true
+	input.aircraft.registered == true
+	input.operation.altitude_ft <= object.get(input.params, "max_altitude_ft", 400)
+	visual_conditions_met
+	lighting_conditions_met
+}
+
+visual_conditions_met if {
+	input.operation.visual_line_of_sight == true
+}
+
+visual_conditions_met if {
+	input.operation.visual_line_of_sight == false
+	input.operation.bvlos_waiver_held == true
+}
+
+lighting_conditions_met if {
+	input.operation.daylight_or_lit == true
+}
+
+policy_metrics := {
+	"remote_pilot_certificated": {
+		"name": "Remote Pilot Certificate Held",
+		"value": input.remote_pilot.certificate_held,
+		"control_passed": input.remote_pilot.certificate_held == true,
+	},
+	"aircraft_registered": {
+		"name": "Aircraft Registered",
+		"value": input.aircraft.registered,
+		"control_passed": input.aircraft.registered == true,
+	},
+	"altitude_within_limit": {
+		"name": "Altitude Within 400ft Limit",
+		"value": input.operation.altitude_ft,
+		"control_passed": input.operation.altitude_ft <= object.get(input.params, "max_altitude_ft", 400),
+	},
+	"visual_conditions": {
+		"name": "VLOS or Waivered BVLOS",
+		"value": visual_conditions_met,
+		"control_passed": visual_conditions_met,
+	},
+	"lighting_conditions": {
+		"name": "Daylight Operation or Anti-Collision Lighting",
+		"value": lighting_conditions_met,
+		"control_passed": lighting_conditions_met,
+	},
+}
+
+report := reporting.compose_report("faa.part_107", allow, policy_metrics)

--- a/international/faa/v1/part_107_test.rego
+++ b/international/faa/v1/part_107_test.rego
@@ -1,0 +1,70 @@
+package international.faa.v1.part_107_test
+
+import data.international.faa.v1.part_107
+import rego.v1
+
+compliant_input := {
+	"remote_pilot": {"certificate_held": true},
+	"aircraft": {"registered": true},
+	"operation": {"altitude_ft": 350, "visual_line_of_sight": true, "daylight_or_lit": true},
+	"params": {},
+}
+
+test_allow_when_fully_compliant if {
+	part_107.allow with input as compliant_input
+}
+
+test_allow_with_bvlos_waiver if {
+	input_data := object.union(compliant_input, {"operation": {
+		"altitude_ft": 350,
+		"visual_line_of_sight": false,
+		"bvlos_waiver_held": true,
+		"daylight_or_lit": true,
+	}})
+	part_107.allow with input as input_data
+}
+
+test_deny_without_remote_pilot_certificate if {
+	input_data := object.union(compliant_input, {"remote_pilot": {"certificate_held": false}})
+	not part_107.allow with input as input_data
+}
+
+test_deny_without_registration if {
+	input_data := object.union(compliant_input, {"aircraft": {"registered": false}})
+	not part_107.allow with input as input_data
+}
+
+test_deny_above_altitude_limit if {
+	input_data := object.union(compliant_input, {"operation": {
+		"altitude_ft": 500,
+		"visual_line_of_sight": true,
+		"daylight_or_lit": true,
+	}})
+	not part_107.allow with input as input_data
+}
+
+test_deny_bvlos_without_waiver if {
+	input_data := object.union(compliant_input, {"operation": {
+		"altitude_ft": 350,
+		"visual_line_of_sight": false,
+		"daylight_or_lit": true,
+	}})
+	not part_107.allow with input as input_data
+}
+
+test_deny_night_operation_without_lighting if {
+	input_data := object.union(compliant_input, {"operation": {
+		"altitude_ft": 350,
+		"visual_line_of_sight": true,
+		"daylight_or_lit": false,
+	}})
+	not part_107.allow with input as input_data
+}
+
+test_allow_with_custom_max_altitude_param if {
+	input_data := object.union(compliant_input, {
+		"operation": {"altitude_ft": 500, "visual_line_of_sight": true, "daylight_or_lit": true},
+		"params": {"max_altitude_ft": 500},
+	})
+	part_107.allow with input as input_data
+}

--- a/international/faa/v1/remote_id.rego
+++ b/international/faa/v1/remote_id.rego
@@ -1,0 +1,54 @@
+# RequiredMetrics:
+#   - aircraft.standard_remote_id_equipped
+#   - aircraft.broadcast_module_attached
+#   - operation.within_fria
+#
+# RequiredParams: none
+package international.faa.v1.remote_id
+
+import data.helper_functions.reporting
+import rego.v1
+
+metadata := {
+	"title": "FAA Remote ID (14 CFR Part 89)",
+	"description": "Evaluates whether a small unmanned aircraft satisfies Remote ID requirements: Standard Remote ID broadcast, a broadcast module, or operation confined to an FAA-Recognized Identification Area.",
+	"version": "1.0.0",
+	"category": "International",
+	"references": [
+		"14 CFR Part 89 - Remote Identification of Unmanned Aircraft",
+	],
+}
+
+default allow := false
+
+allow if {
+	input.aircraft.standard_remote_id_equipped == true
+}
+
+allow if {
+	input.aircraft.broadcast_module_attached == true
+}
+
+allow if {
+	input.operation.within_fria == true
+}
+
+default compliance_method := "none"
+
+compliance_method := "standard_remote_id" if {
+	input.aircraft.standard_remote_id_equipped == true
+} else := "broadcast_module" if {
+	input.aircraft.broadcast_module_attached == true
+} else := "fria_exempt" if {
+	input.operation.within_fria == true
+}
+
+policy_metrics := {
+	"remote_id_compliance_method": {
+		"name": "Remote ID Compliance Method",
+		"value": compliance_method,
+		"control_passed": compliance_method != "none",
+	},
+}
+
+report := reporting.compose_report("faa.remote_id", allow, policy_metrics)

--- a/international/faa/v1/remote_id_test.rego
+++ b/international/faa/v1/remote_id_test.rego
@@ -1,0 +1,40 @@
+package international.faa.v1.remote_id_test
+
+import data.international.faa.v1.remote_id
+import rego.v1
+
+test_allow_with_standard_remote_id if {
+	remote_id.allow with input as {
+		"aircraft": {"standard_remote_id_equipped": true, "broadcast_module_attached": false},
+		"operation": {"within_fria": false},
+	}
+}
+
+test_allow_with_broadcast_module if {
+	remote_id.allow with input as {
+		"aircraft": {"standard_remote_id_equipped": false, "broadcast_module_attached": true},
+		"operation": {"within_fria": false},
+	}
+}
+
+test_allow_within_fria if {
+	remote_id.allow with input as {
+		"aircraft": {"standard_remote_id_equipped": false, "broadcast_module_attached": false},
+		"operation": {"within_fria": true},
+	}
+}
+
+test_deny_when_none_apply if {
+	not remote_id.allow with input as {
+		"aircraft": {"standard_remote_id_equipped": false, "broadcast_module_attached": false},
+		"operation": {"within_fria": false},
+	}
+}
+
+test_report_identifies_compliance_method if {
+	report := remote_id.report with input as {
+		"aircraft": {"standard_remote_id_equipped": true, "broadcast_module_attached": false},
+		"operation": {"within_fria": false},
+	}
+	report.metrics.remote_id_compliance_method.value == "standard_remote_id"
+}

--- a/international/icao/README.md
+++ b/international/icao/README.md
@@ -1,0 +1,11 @@
+# ICAO (International Civil Aviation Organization) Policies
+
+Source: **ICAO Doc 10019 - Manual on Remotely Piloted Aircraft Systems (RPAS)**
+
+## Directory Structure
+
+- **v1/**: `doc_10019.rego` - checks command-and-control (C2) link lost-link procedures, detect-and-avoid equipage, and remote pilot qualification
+
+## Disclaimer
+
+The policies provided in this directory are for informational purposes only and do not constitute legal advice. These policies are based on publicly available information and interpretations of relevant regulations and frameworks. Users are advised to consult with legal professionals for specific guidance related to their AI systems and compliance obligations.

--- a/international/icao/v1/doc_10019.rego
+++ b/international/icao/v1/doc_10019.rego
@@ -1,0 +1,48 @@
+# RequiredMetrics:
+#   - system.c2_link.lost_link_procedure_defined
+#   - system.detect_and_avoid.equipped
+#   - system.remote_pilot.qualified
+#
+# RequiredParams: none
+package international.icao.v1.doc_10019
+
+import data.helper_functions.reporting
+import rego.v1
+
+metadata := {
+	"title": "ICAO Doc 10019 - Manual on RPAS",
+	"description": "Evaluates command and control link resilience, detect-and-avoid capability, and remote pilot qualification for remotely piloted aircraft systems.",
+	"version": "1.0.0",
+	"category": "International",
+	"references": [
+		"ICAO Doc 10019 - Manual on Remotely Piloted Aircraft Systems, Chapter 3 (C2 Link) and Chapter 9 (Detect and Avoid)",
+	],
+}
+
+default allow := false
+
+allow if {
+	input.system.c2_link.lost_link_procedure_defined == true
+	input.system.detect_and_avoid.equipped == true
+	input.system.remote_pilot.qualified == true
+}
+
+policy_metrics := {
+	"lost_link_procedure_defined": {
+		"name": "Lost Link Procedure Defined",
+		"value": object.get(input.system.c2_link, "lost_link_procedure_defined", false),
+		"control_passed": object.get(input.system.c2_link, "lost_link_procedure_defined", false) == true,
+	},
+	"detect_and_avoid_equipped": {
+		"name": "Detect and Avoid Equipped",
+		"value": object.get(input.system.detect_and_avoid, "equipped", false),
+		"control_passed": object.get(input.system.detect_and_avoid, "equipped", false) == true,
+	},
+	"remote_pilot_qualified": {
+		"name": "Remote Pilot Qualified",
+		"value": object.get(input.system.remote_pilot, "qualified", false),
+		"control_passed": object.get(input.system.remote_pilot, "qualified", false) == true,
+	},
+}
+
+report := reporting.compose_report("icao.doc_10019", allow, policy_metrics)

--- a/international/icao/v1/doc_10019_test.rego
+++ b/international/icao/v1/doc_10019_test.rego
@@ -1,0 +1,46 @@
+package international.icao.v1.doc_10019_test
+
+import data.international.icao.v1.doc_10019
+import rego.v1
+
+test_allow_when_all_requirements_met if {
+	doc_10019.allow with input as {"system": {
+		"c2_link": {"lost_link_procedure_defined": true},
+		"detect_and_avoid": {"equipped": true},
+		"remote_pilot": {"qualified": true},
+	}}
+}
+
+test_deny_when_no_lost_link_procedure if {
+	not doc_10019.allow with input as {"system": {
+		"c2_link": {"lost_link_procedure_defined": false},
+		"detect_and_avoid": {"equipped": true},
+		"remote_pilot": {"qualified": true},
+	}}
+}
+
+test_deny_when_not_equipped_for_detect_and_avoid if {
+	not doc_10019.allow with input as {"system": {
+		"c2_link": {"lost_link_procedure_defined": true},
+		"detect_and_avoid": {"equipped": false},
+		"remote_pilot": {"qualified": true},
+	}}
+}
+
+test_deny_when_remote_pilot_not_qualified if {
+	not doc_10019.allow with input as {"system": {
+		"c2_link": {"lost_link_procedure_defined": true},
+		"detect_and_avoid": {"equipped": true},
+		"remote_pilot": {"qualified": false},
+	}}
+}
+
+test_report_reflects_compliant_state if {
+	report := doc_10019.report with input as {"system": {
+		"c2_link": {"lost_link_procedure_defined": true},
+		"detect_and_avoid": {"equipped": true},
+		"remote_pilot": {"qualified": true},
+	}}
+	report.result == true
+	report.metrics.remote_pilot_qualified.control_passed == true
+}

--- a/international/standards/README.md
+++ b/international/standards/README.md
@@ -1,0 +1,13 @@
+# Aviation Industry Standards Policies
+
+This directory contains OPA Rego policies for compliance with international aviation industry standards (as opposed to a single national or regional regulator).
+
+## Directory Structure
+
+- **v1/**:
+  - `rtca_do_365.rego` - RTCA DO-365 Detect and Avoid Minimum Operational Performance Standards: surveillance volume and alert timeliness
+  - `iso_21384.rego` - ISO 21384 UAS general requirements: safety management system, risk assessment, documented operational procedures
+
+## Disclaimer
+
+The policies provided in this directory are for informational purposes only and do not constitute legal advice. These policies are based on publicly available information and interpretations of relevant regulations and frameworks. Users are advised to consult with legal professionals for specific guidance related to their AI systems and compliance obligations.

--- a/international/standards/v1/iso_21384.rego
+++ b/international/standards/v1/iso_21384.rego
@@ -1,0 +1,49 @@
+# RequiredMetrics:
+#   - safety_management.system_established
+#   - safety_management.risk_assessment_completed
+#   - operations.procedures_documented
+#
+# RequiredParams: none
+package international.standards.v1.iso_21384
+
+import data.helper_functions.reporting
+import rego.v1
+
+metadata := {
+	"title": "ISO 21384 - UAS General Requirements",
+	"description": "Evaluates UAS operator compliance with ISO 21384 general requirements: an established safety management system, completed risk assessment, and documented operational procedures.",
+	"version": "1.0.0",
+	"category": "International",
+	"references": [
+		"ISO 21384-1:2019 - Unmanned aircraft systems, Part 1: General requirements",
+		"ISO 21384-3:2023 - Unmanned aircraft systems, Part 3: Operational procedures",
+	],
+}
+
+default allow := false
+
+allow if {
+	input.safety_management.system_established == true
+	input.safety_management.risk_assessment_completed == true
+	input.operations.procedures_documented == true
+}
+
+policy_metrics := {
+	"safety_management_system_established": {
+		"name": "Safety Management System Established",
+		"value": object.get(input.safety_management, "system_established", false),
+		"control_passed": object.get(input.safety_management, "system_established", false) == true,
+	},
+	"risk_assessment_completed": {
+		"name": "Risk Assessment Completed",
+		"value": object.get(input.safety_management, "risk_assessment_completed", false),
+		"control_passed": object.get(input.safety_management, "risk_assessment_completed", false) == true,
+	},
+	"operational_procedures_documented": {
+		"name": "Operational Procedures Documented",
+		"value": object.get(input.operations, "procedures_documented", false),
+		"control_passed": object.get(input.operations, "procedures_documented", false) == true,
+	},
+}
+
+report := reporting.compose_report("standards.iso_21384", allow, policy_metrics)

--- a/international/standards/v1/iso_21384_test.rego
+++ b/international/standards/v1/iso_21384_test.rego
@@ -1,0 +1,32 @@
+package international.standards.v1.iso_21384_test
+
+import data.international.standards.v1.iso_21384
+import rego.v1
+
+test_allow_when_fully_compliant if {
+	iso_21384.allow with input as {
+		"safety_management": {"system_established": true, "risk_assessment_completed": true},
+		"operations": {"procedures_documented": true},
+	}
+}
+
+test_deny_without_safety_management_system if {
+	not iso_21384.allow with input as {
+		"safety_management": {"system_established": false, "risk_assessment_completed": true},
+		"operations": {"procedures_documented": true},
+	}
+}
+
+test_deny_without_risk_assessment if {
+	not iso_21384.allow with input as {
+		"safety_management": {"system_established": true, "risk_assessment_completed": false},
+		"operations": {"procedures_documented": true},
+	}
+}
+
+test_deny_without_documented_procedures if {
+	not iso_21384.allow with input as {
+		"safety_management": {"system_established": true, "risk_assessment_completed": true},
+		"operations": {"procedures_documented": false},
+	}
+}

--- a/international/standards/v1/rtca_do_365.rego
+++ b/international/standards/v1/rtca_do_365.rego
@@ -1,0 +1,49 @@
+# RequiredMetrics:
+#   - daa_system.surveillance_volume_nm
+#   - daa_system.alert_timeliness_compliant
+#   - daa_system.equipped
+#
+# RequiredParams:
+#   - min_surveillance_volume_nm (default 1.0)
+package international.standards.v1.rtca_do_365
+
+import data.helper_functions.reporting
+import rego.v1
+
+metadata := {
+	"title": "RTCA DO-365 - Detect and Avoid MOPS",
+	"description": "Evaluates whether a UAS detect-and-avoid system meets the surveillance volume and alert-timeliness requirements of RTCA DO-365 Minimum Operational Performance Standards.",
+	"version": "1.0.0",
+	"category": "International",
+	"references": [
+		"RTCA DO-365 - Minimum Operational Performance Standards (MOPS) for Detect and Avoid Systems",
+	],
+}
+
+default allow := false
+
+allow if {
+	input.daa_system.equipped == true
+	input.daa_system.surveillance_volume_nm >= object.get(input.params, "min_surveillance_volume_nm", 1.0)
+	input.daa_system.alert_timeliness_compliant == true
+}
+
+policy_metrics := {
+	"daa_equipped": {
+		"name": "Detect and Avoid System Equipped",
+		"value": object.get(input.daa_system, "equipped", false),
+		"control_passed": object.get(input.daa_system, "equipped", false) == true,
+	},
+	"surveillance_volume_sufficient": {
+		"name": "Surveillance Volume Meets Minimum",
+		"value": object.get(input.daa_system, "surveillance_volume_nm", 0),
+		"control_passed": object.get(input.daa_system, "surveillance_volume_nm", 0) >= object.get(input.params, "min_surveillance_volume_nm", 1.0),
+	},
+	"alert_timeliness_compliant": {
+		"name": "Alert Timeliness Compliant",
+		"value": object.get(input.daa_system, "alert_timeliness_compliant", false),
+		"control_passed": object.get(input.daa_system, "alert_timeliness_compliant", false) == true,
+	},
+}
+
+report := reporting.compose_report("standards.rtca_do_365", allow, policy_metrics)

--- a/international/standards/v1/rtca_do_365_test.rego
+++ b/international/standards/v1/rtca_do_365_test.rego
@@ -1,0 +1,39 @@
+package international.standards.v1.rtca_do_365_test
+
+import data.international.standards.v1.rtca_do_365
+import rego.v1
+
+test_allow_when_fully_compliant if {
+	rtca_do_365.allow with input as {
+		"daa_system": {"equipped": true, "surveillance_volume_nm": 2.5, "alert_timeliness_compliant": true},
+		"params": {},
+	}
+}
+
+test_deny_when_not_equipped if {
+	not rtca_do_365.allow with input as {
+		"daa_system": {"equipped": false, "surveillance_volume_nm": 2.5, "alert_timeliness_compliant": true},
+		"params": {},
+	}
+}
+
+test_deny_when_surveillance_volume_below_minimum if {
+	not rtca_do_365.allow with input as {
+		"daa_system": {"equipped": true, "surveillance_volume_nm": 0.5, "alert_timeliness_compliant": true},
+		"params": {},
+	}
+}
+
+test_deny_when_alerts_not_timely if {
+	not rtca_do_365.allow with input as {
+		"daa_system": {"equipped": true, "surveillance_volume_nm": 2.5, "alert_timeliness_compliant": false},
+		"params": {},
+	}
+}
+
+test_allow_with_custom_minimum_param if {
+	rtca_do_365.allow with input as {
+		"daa_system": {"equipped": true, "surveillance_volume_nm": 3.5, "alert_timeliness_compliant": true},
+		"params": {"min_surveillance_volume_nm": 3.0},
+	}
+}


### PR DESCRIPTION
## What

Completes GOP-2 properly. `feature/gop-2-aviation-directory-structure` turned out to be pure scaffolding on inspection: all 19 files across `international/{icao,faa,easa,standards}` and `industry_specific/aviation` were an identical placeholder template (`default compliant := false`, hardcoded `non_compliant := true`, a canned "implementation is pending" message). Zero real compliance logic, zero tests. Even its own READMEs overclaimed relative to that placeholder code (FAA's README described 5 files; 2 existed).

This PR replaces all 19 with real logic and a full test suite, keeping the branch's original directory layout since it was reasonable.

**International (7):** `icao/v1/doc_10019`, `faa/v1/part_107`, `faa/v1/remote_id`, `easa/v1/regulation_2019_947`, `easa/v1/sora`, `standards/v1/rtca_do_365`, `standards/v1/iso_21384`

**Industry-specific/aviation (12):** across `airworthiness/`, `autonomous_systems/`, `data_management/`, `flight_operations/`

Every policy follows the repo's standard shape: metadata block with real regulatory citations, default-deny, `reporting.compose_report()` for output, and a sibling `_test.rego` covering the allow path and each deny path individually.

## Why this framing, not "add tests to existing scaffolds"

Because there was no existing logic to test. This is new policy authorship, same as any other framework in this repo — an engineering best-effort reading of the source regulations (FAA Part 107 and Remote ID, EASA 2019/947 and SORA, ICAO Doc 10019, RTCA DO-365, ISO 21384), open to public correction like everything else here, not a claim of legal authority. Please push back hard on any interpretation that's off.

## Docs

Also updates every place that referenced policy/framework counts to the new real totals (85 policies, 8 international frameworks, 5 industry verticals): `README.md` (badges, tree, comparison table, hero diagrams), `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `docs/coverage/README.md`, and the hero/OG/directory-tree SVGs in both light and dark. Fixed the two parent READMEs (`industry_specific/`, `international/`) to list the new directories.

## Verification

- `opa check --ignore custom/ .` — clean
- `regal lint --ignore-files custom/ .` — 0 violations across 124 files
- `opa test . --ignore custom/` — 225/226 pass (the one failure is a pre-existing, unrelated NIST test failure on `main`, not touched by this PR)